### PR TITLE
feat: implement Phase 3 observer statistics and history logging

### DIFF
--- a/src/emergent_constitution/lead.py
+++ b/src/emergent_constitution/lead.py
@@ -17,6 +17,7 @@ from emergent_constitution.models.constitution import Constitution
 from emergent_constitution.models.history import HistoryEntry, SimulationOutput
 from emergent_constitution.models.proposal import Proposal, VoteOutcome
 from emergent_constitution.models.tick import TickState
+from emergent_constitution.observer import observe_tick
 from emergent_constitution.rng import SimulationRNG
 from emergent_constitution.voting import (
     apply_passed_proposals,
@@ -39,6 +40,7 @@ class Lead:
         self.tick_state: TickState
         self.rng: SimulationRNG
         self.history: list[HistoryEntry] = []
+        self.last_observed_constitution: Constitution | None = None
         self.tick_state, self.rng = initialize_simulation(config)
         log.info("simulation.initialized", num_agents=config.num_agents, seed=config.seed)
 
@@ -210,11 +212,23 @@ class Lead:
         agents: list[AgentState],
         constitution: Constitution,
     ) -> None:
-        """Record observation statistics. Phase 3 stub: no-op.
+        """Record observation statistics at observer-interval ticks.
 
         Args:
             tick: Current tick number.
             agents: Current agent states.
             constitution: Current constitution.
         """
-        _ = tick, agents, constitution
+        if tick % self.config.observer_interval != 0:
+            return
+
+        entry = observe_tick(tick, agents, constitution, self.last_observed_constitution)
+        self.history.append(entry)
+        self.last_observed_constitution = constitution.model_copy(deep=True)
+        log.info(
+            "observation.recorded",
+            tick=tick,
+            gini=round(entry.gini, 4),
+            mean_wealth=round(entry.mean_wealth, 2),
+            rule_changes=len(entry.rule_changes),
+        )

--- a/src/emergent_constitution/observer.py
+++ b/src/emergent_constitution/observer.py
@@ -1,0 +1,77 @@
+"""Observer/Statistician — aggregate statistics and rule-change detection.
+
+All functions are pure: they take state and return results without
+mutating any inputs.
+"""
+
+from __future__ import annotations
+
+import statistics
+
+from emergent_constitution.citizen import compute_gini
+from emergent_constitution.models.agent import AgentState
+from emergent_constitution.models.constitution import Constitution
+from emergent_constitution.models.history import HistoryEntry
+
+
+def observe_tick(
+    tick: int,
+    agents: list[AgentState],
+    constitution: Constitution,
+    prev_constitution: Constitution | None,
+) -> HistoryEntry:
+    """Compute aggregate statistics for the current tick.
+
+    Args:
+        tick: Current tick number.
+        agents: Current agent states.
+        constitution: Current constitution.
+        prev_constitution: Constitution at the previous observation, or None
+            if this is the first observation.
+
+    Returns:
+        HistoryEntry with computed statistics and a deep-copied constitution snapshot.
+    """
+    wealths = [a.wealth for a in agents]
+
+    gini = compute_gini(wealths)
+    mean_wealth = statistics.mean(wealths) if wealths else 0.0
+    median_wealth = statistics.median(wealths) if wealths else 0.0
+    total_output = sum(a.productivity for a in agents)
+    rule_changes = _detect_rule_changes(prev_constitution, constitution)
+
+    return HistoryEntry(
+        tick=tick,
+        gini=gini,
+        total_output=total_output,
+        mean_wealth=mean_wealth,
+        median_wealth=median_wealth,
+        rule_changes=rule_changes,
+        constitution_snapshot=constitution.model_copy(deep=True),
+    )
+
+
+def _detect_rule_changes(
+    prev: Constitution | None,
+    current: Constitution,
+) -> list[str]:
+    """Detect which constitutional fields changed between observations.
+
+    Args:
+        prev: Constitution at the previous observation, or None for first observation.
+        current: Constitution at the current observation.
+
+    Returns:
+        List of human-readable change descriptions, e.g. ``"tax_rate: 0.0 → 0.25"``.
+    """
+    if prev is None:
+        return []
+
+    changes: list[str] = []
+    for field_name in ("property_rule", "tax_rate", "voting_rule", "redistribution_rule"):
+        old_val = getattr(prev, field_name)
+        new_val = getattr(current, field_name)
+        if old_val != new_val:
+            changes.append(f"{field_name}: {old_val} → {new_val}")
+
+    return changes

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -88,3 +88,52 @@ class TestIntegrationPhase2:
         for agent in output.final_agent_states:
             assert agent.wealth >= 0.0
             assert agent.productivity > 0.0
+
+
+class TestIntegrationPhase3:
+    """Phase 3 integration tests — observer output and history."""
+
+    def test_full_output_structure(self):
+        """SimulationOutput has non-empty history, valid constitution, all agents."""
+        config = SimulationConfig(num_agents=10, max_ticks=20, seed=42, observer_interval=5)
+        output = Lead(config).run()
+        assert len(output.history) > 0
+        assert output.constitution is not None
+        assert len(output.final_agent_states) == 10
+        assert output.seed == 42
+        assert output.total_ticks == 20
+
+    def test_gini_evolution(self):
+        """History captures changing Gini over time with 50 agents."""
+        config = SimulationConfig(
+            num_agents=50,
+            max_ticks=200,
+            seed=42,
+            proposal_interval=5,
+            observer_interval=10,
+        )
+        output = Lead(config).run()
+        ginis = [entry.gini for entry in output.history]
+        assert len(ginis) == 200 // 10
+        # Gini values should be valid
+        for g in ginis:
+            assert 0.0 <= g <= 1.0
+        # With heterogeneous agents, Gini should not be constant at 0
+        assert any(g > 0.0 for g in ginis)
+
+    def test_constitution_snapshots_in_history(self):
+        """Each history entry has a constitution snapshot; snapshots differ when rules change."""
+        config = SimulationConfig(
+            num_agents=50,
+            max_ticks=100,
+            seed=42,
+            proposal_interval=5,
+            observer_interval=5,
+        )
+        output = Lead(config).run()
+        for entry in output.history:
+            assert entry.constitution_snapshot is not None
+        # With active governance, at least two snapshots should differ
+        snapshots = [e.constitution_snapshot for e in output.history]
+        unique = {s.model_dump_json() for s in snapshots}
+        assert len(unique) > 1, "Expected constitution snapshots to change over time"

--- a/tests/test_lead.py
+++ b/tests/test_lead.py
@@ -97,3 +97,54 @@ class TestLeadPhase2:
             or output.constitution.redistribution_rule.value != "flat"
         )
         assert changed, "Constitution should evolve with 50 agents over 100 ticks"
+
+
+class TestLeadPhase3:
+    """Phase 3 tests — observer statistics and history logging."""
+
+    def test_observations_on_interval_ticks(self):
+        """History entries should only be recorded on observer-interval ticks."""
+        config = SimulationConfig(num_agents=5, max_ticks=20, seed=42, observer_interval=5)
+        lead = Lead(config)
+        lead.run()
+        expected_ticks = {5, 10, 15, 20}
+        actual_ticks = {entry.tick for entry in lead.history}
+        assert actual_ticks == expected_ticks
+
+    def test_history_length_matches_intervals(self):
+        """Number of history entries == max_ticks // observer_interval."""
+        config = SimulationConfig(num_agents=5, max_ticks=20, seed=42, observer_interval=5)
+        output = Lead(config).run()
+        assert len(output.history) == 20 // 5
+
+    def test_history_statistics_valid(self):
+        """All statistics in history entries are within valid ranges."""
+        config = SimulationConfig(num_agents=10, max_ticks=30, seed=42, observer_interval=5)
+        output = Lead(config).run()
+        for entry in output.history:
+            assert 0.0 <= entry.gini <= 1.0, f"Invalid Gini {entry.gini} at tick {entry.tick}"
+            assert entry.mean_wealth >= 0.0
+            assert entry.median_wealth >= 0.0
+            assert entry.total_output > 0.0
+
+    def test_rule_changes_tracked(self):
+        """With active governance, rule changes should appear in history."""
+        config = SimulationConfig(
+            num_agents=50,
+            max_ticks=100,
+            seed=42,
+            proposal_interval=5,
+            observer_interval=5,
+        )
+        output = Lead(config).run()
+        all_changes = [ch for entry in output.history for ch in entry.rule_changes]
+        assert len(all_changes) > 0, "Expected at least one rule change to be tracked"
+
+    def test_deterministic_history(self):
+        """Same seed produces identical history."""
+        config = SimulationConfig(num_agents=10, max_ticks=30, seed=42, observer_interval=5)
+        output1 = Lead(config).run()
+        output2 = Lead(config).run()
+        assert len(output1.history) == len(output2.history)
+        for e1, e2 in zip(output1.history, output2.history, strict=True):
+            assert e1 == e2

--- a/tests/test_observer.py
+++ b/tests/test_observer.py
@@ -1,0 +1,137 @@
+"""Tests for the Observer/Statistician module."""
+
+from __future__ import annotations
+
+import pytest
+
+from emergent_constitution.models.agent import AgentState, UtilityParams, ValueVector
+from emergent_constitution.models.constitution import (
+    Constitution,
+    PropertyRule,
+    RedistributionRule,
+    VotingRule,
+)
+from emergent_constitution.observer import _detect_rule_changes, observe_tick
+
+
+def _make_agent(agent_id: str, wealth: float, productivity: float) -> AgentState:
+    """Helper to create an agent with given wealth and productivity."""
+    return AgentState(
+        id=agent_id,
+        wealth=wealth,
+        productivity=productivity,
+        utility_params=UtilityParams(alpha=0.5, beta=0.3, gamma=0.2),
+        value_vector=ValueVector(equality=0.5, liberty=0.5),
+    )
+
+
+class TestObserveTick:
+    """Tests for observe_tick statistics computation."""
+
+    def test_correct_gini(self):
+        """Gini is computed correctly for known distribution."""
+        agents = [
+            _make_agent("a0", wealth=0.0, productivity=10.0),
+            _make_agent("a1", wealth=100.0, productivity=10.0),
+        ]
+        entry = observe_tick(1, agents, Constitution(), None)
+        # Gini for [0, 100] = 0.5
+        assert entry.gini == pytest.approx(0.5, abs=1e-6)
+
+    def test_correct_mean_wealth(self):
+        agents = [
+            _make_agent("a0", wealth=100.0, productivity=10.0),
+            _make_agent("a1", wealth=200.0, productivity=10.0),
+            _make_agent("a2", wealth=300.0, productivity=10.0),
+        ]
+        entry = observe_tick(1, agents, Constitution(), None)
+        assert entry.mean_wealth == pytest.approx(200.0)
+
+    def test_correct_median_wealth(self):
+        agents = [
+            _make_agent("a0", wealth=100.0, productivity=10.0),
+            _make_agent("a1", wealth=200.0, productivity=10.0),
+            _make_agent("a2", wealth=900.0, productivity=10.0),
+        ]
+        entry = observe_tick(1, agents, Constitution(), None)
+        assert entry.median_wealth == pytest.approx(200.0)
+
+    def test_correct_total_output(self):
+        agents = [
+            _make_agent("a0", wealth=100.0, productivity=5.0),
+            _make_agent("a1", wealth=100.0, productivity=15.0),
+            _make_agent("a2", wealth=100.0, productivity=10.0),
+        ]
+        entry = observe_tick(1, agents, Constitution(), None)
+        assert entry.total_output == pytest.approx(30.0)
+
+    def test_tick_recorded(self):
+        agents = [_make_agent("a0", wealth=100.0, productivity=10.0)]
+        entry = observe_tick(42, agents, Constitution(), None)
+        assert entry.tick == 42
+
+    def test_constitution_snapshot_is_deep_copy(self):
+        """Snapshot should be independent of the passed-in constitution."""
+        constitution = Constitution(tax_rate=0.2)
+        agents = [_make_agent("a0", wealth=100.0, productivity=10.0)]
+        entry = observe_tick(1, agents, constitution, None)
+
+        # Mutate the original — snapshot should not change
+        constitution.tax_rate = 0.9
+        assert entry.constitution_snapshot.tax_rate == pytest.approx(0.2)
+
+    def test_single_agent(self):
+        """Single agent: Gini=0, mean=median=wealth."""
+        agents = [_make_agent("a0", wealth=50.0, productivity=10.0)]
+        entry = observe_tick(1, agents, Constitution(), None)
+        assert entry.gini == pytest.approx(0.0)
+        assert entry.mean_wealth == pytest.approx(50.0)
+        assert entry.median_wealth == pytest.approx(50.0)
+
+    def test_all_equal_wealth(self):
+        """All agents with equal wealth: Gini=0."""
+        agents = [_make_agent(f"a{i}", wealth=100.0, productivity=10.0) for i in range(5)]
+        entry = observe_tick(1, agents, Constitution(), None)
+        assert entry.gini == pytest.approx(0.0)
+
+    def test_zero_wealth(self):
+        """All agents with zero wealth: Gini=0."""
+        agents = [_make_agent(f"a{i}", wealth=0.0, productivity=10.0) for i in range(3)]
+        entry = observe_tick(1, agents, Constitution(), None)
+        assert entry.gini == pytest.approx(0.0)
+
+
+class TestDetectRuleChanges:
+    """Tests for rule-change detection."""
+
+    def test_no_changes(self):
+        prev = Constitution()
+        current = Constitution()
+        assert _detect_rule_changes(prev, current) == []
+
+    def test_first_observation_no_changes(self):
+        """First observation (prev=None) always returns empty list."""
+        assert _detect_rule_changes(None, Constitution()) == []
+
+    def test_single_change(self):
+        prev = Constitution(tax_rate=0.0)
+        current = Constitution(tax_rate=0.25)
+        changes = _detect_rule_changes(prev, current)
+        assert len(changes) == 1
+        assert "tax_rate" in changes[0]
+        assert "0.0" in changes[0]
+        assert "0.25" in changes[0]
+
+    def test_multiple_changes(self):
+        prev = Constitution()
+        current = Constitution(
+            tax_rate=0.3,
+            property_rule=PropertyRule.COMMUNAL,
+            voting_rule=VotingRule.SUPERMAJORITY,
+            redistribution_rule=RedistributionRule.PROGRESSIVE,
+        )
+        changes = _detect_rule_changes(prev, current)
+        assert len(changes) == 4
+        changed_fields = {c.split(":")[0] for c in changes}
+        expected = {"tax_rate", "property_rule", "voting_rule", "redistribution_rule"}
+        assert changed_fields == expected


### PR DESCRIPTION
## Summary
- Add `observer.py` module with pure functions (`observe_tick`, `_detect_rule_changes`) that compute Gini coefficient, mean/median wealth, total output, and detect constitutional rule changes between observations
- Fill the `_observe` stub in `lead.py` — gates on `observer_interval`, records `HistoryEntry` objects, tracks `last_observed_constitution` for change detection
- Add 21 new tests across `test_observer.py`, `test_lead.py` (TestLeadPhase3), and `test_integration.py` (TestIntegrationPhase3)

Traces to REQ-005 (aggregate statistics every K ticks), REQ-006 (constitutional summary + history log), PROP-001 (determinism).

## Test plan
- [x] 154 tests pass (133 existing + 21 new)
- [x] 97% code coverage (100% on `observer.py` and `lead.py`)
- [x] `ruff check` and `ruff format` clean
- [x] Determinism verified: same seed → identical history

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Interval-based observation recording with full history tracking
  * Economic metrics computation and tracking (wealth distribution, inequality indices)
  * Rule change detection and event logging with tick information
  * Constitutional state snapshots captured in history for temporal comparison

* **Tests**
  * Added integration tests validating output structure, metrics evolution, and state consistency
  * Added unit tests for observation logic and rule change detection

<!-- end of auto-generated comment: release notes by coderabbit.ai -->