### PR TITLE
feat: add Pareto efficiency computation to observer

### DIFF
--- a/src/emergent_constitution/models/history.py
+++ b/src/emergent_constitution/models/history.py
@@ -17,6 +17,7 @@ class HistoryEntry(BaseModel):
         total_output: Total production output this tick.
         mean_wealth: Mean agent wealth.
         median_wealth: Median agent wealth.
+        pareto_score: Pareto efficiency score (1.0 = fully efficient).
         rule_changes: List of rule-change descriptions this period.
         constitution_snapshot: Copy of the constitution at this tick.
     """
@@ -26,6 +27,7 @@ class HistoryEntry(BaseModel):
     total_output: float = Field(ge=0.0)
     mean_wealth: float = Field(ge=0.0)
     median_wealth: float = Field(ge=0.0)
+    pareto_score: float = Field(ge=0.0, le=1.0, default=1.0)
     rule_changes: list[str] = Field(default_factory=list)
     constitution_snapshot: Constitution
 

--- a/src/emergent_constitution/observer.py
+++ b/src/emergent_constitution/observer.py
@@ -6,12 +6,98 @@ mutating any inputs.
 
 from __future__ import annotations
 
+import math
 import statistics
 
 from emergent_constitution.citizen import compute_gini
 from emergent_constitution.models.agent import AgentState
 from emergent_constitution.models.constitution import Constitution
 from emergent_constitution.models.history import HistoryEntry
+
+# Small transfer amount used to test for Pareto improvements.
+_TRANSFER_DELTA = 1.0
+
+
+def _compute_utility(
+    agent: AgentState,
+    wealth: float,
+    public_goods: float,
+) -> float:
+    """Compute Cobb-Douglas utility for an agent.
+
+    Args:
+        agent: The agent whose utility parameters to use.
+        wealth: Consumption/wealth level.
+        public_goods: Public goods per capita.
+
+    Returns:
+        Utility value (non-negative).
+    """
+    p = agent.utility_params
+    # U = wealth^alpha * leisure^beta * public_goods^gamma
+    # Leisure is fixed at 1.0 for simplicity.
+    leisure = 1.0
+    try:
+        return (
+            math.pow(wealth, p.alpha) * math.pow(leisure, p.beta) * math.pow(public_goods, p.gamma)
+        )
+    except (ValueError, OverflowError):
+        return 0.0
+
+
+def compute_pareto_efficiency(agents: list[AgentState]) -> float:
+    """Estimate Pareto efficiency as fraction of pairs with no improving transfer.
+
+    Tests each pair of agents: can a small transfer from the richer to the
+    poorer improve the recipient without harming the donor? The score is
+    the fraction of pairs where no such improvement exists (1.0 = fully
+    Pareto efficient).
+
+    Args:
+        agents: List of agent states.
+
+    Returns:
+        Score in [0, 1]. 1.0 means no Pareto improvements found.
+    """
+    n = len(agents)
+    if n <= 1:
+        return 1.0
+
+    total_wealth = sum(a.wealth for a in agents)
+    public_goods_per_capita = total_wealth / n if n > 0 else 0.0
+
+    pairs_checked = 0
+    improvements_found = 0
+
+    for i in range(n):
+        for j in range(i + 1, n):
+            if agents[i].wealth >= agents[j].wealth:
+                a_rich, a_poor = agents[i], agents[j]
+            else:
+                a_rich, a_poor = agents[j], agents[i]
+
+            # Skip if the richer agent can't afford the transfer.
+            if a_rich.wealth < _TRANSFER_DELTA:
+                pairs_checked += 1
+                continue
+
+            u_rich_before = _compute_utility(a_rich, a_rich.wealth, public_goods_per_capita)
+            u_poor_before = _compute_utility(a_poor, a_poor.wealth, public_goods_per_capita)
+            u_rich_after = _compute_utility(
+                a_rich, a_rich.wealth - _TRANSFER_DELTA, public_goods_per_capita
+            )
+            u_poor_after = _compute_utility(
+                a_poor, a_poor.wealth + _TRANSFER_DELTA, public_goods_per_capita
+            )
+
+            pairs_checked += 1
+            # Pareto improvement: recipient better off, donor no worse off.
+            if u_poor_after > u_poor_before and u_rich_after >= u_rich_before:
+                improvements_found += 1
+
+    if pairs_checked == 0:
+        return 1.0
+    return 1.0 - (improvements_found / pairs_checked)
 
 
 def observe_tick(
@@ -38,6 +124,7 @@ def observe_tick(
     mean_wealth = statistics.mean(wealths) if wealths else 0.0
     median_wealth = statistics.median(wealths) if wealths else 0.0
     total_output = sum(a.productivity for a in agents)
+    pareto_score = compute_pareto_efficiency(agents)
     rule_changes = _detect_rule_changes(prev_constitution, constitution)
 
     return HistoryEntry(
@@ -46,6 +133,7 @@ def observe_tick(
         total_output=total_output,
         mean_wealth=mean_wealth,
         median_wealth=median_wealth,
+        pareto_score=pareto_score,
         rule_changes=rule_changes,
         constitution_snapshot=constitution.model_copy(deep=True),
     )

--- a/src/emergent_constitution/reporter.py
+++ b/src/emergent_constitution/reporter.py
@@ -12,6 +12,7 @@ from emergent_constitution.citizen import compute_gini
 from emergent_constitution.models.agent import AgentState
 from emergent_constitution.models.constitution import Constitution
 from emergent_constitution.models.history import HistoryEntry, SimulationOutput
+from emergent_constitution.observer import compute_pareto_efficiency
 
 
 def generate_report(output: SimulationOutput) -> str:
@@ -86,6 +87,7 @@ def _format_wealth_distribution(agents: list[AgentState]) -> str:
     wealths = [a.wealth for a in agents]
     n = len(wealths)
     gini = compute_gini(wealths)
+    pareto_score = compute_pareto_efficiency(agents)
     mean = statistics.mean(wealths)
     median = statistics.median(wealths)
     stdev = statistics.stdev(wealths) if n >= 2 else "N/A"
@@ -100,6 +102,7 @@ def _format_wealth_distribution(agents: list[AgentState]) -> str:
         f"- **Median:** {median:.2f}",
         f"- **Std dev:** {stdev_str}",
         f"- **Gini coefficient:** {gini:.4f}",
+        f"- **Pareto efficiency:** {pareto_score:.4f}",
     ]
 
     # Quintile breakdown (only if enough agents)
@@ -154,21 +157,23 @@ def _format_statistics_evolution(history: list[HistoryEntry]) -> str:
         history: List of HistoryEntry objects.
 
     Returns:
-        Markdown table of Gini, total output, mean/median wealth per observation tick.
+        Markdown table of Gini, Pareto score, total output,
+        mean/median wealth per observation tick.
     """
     if not history:
         return "## Statistics Over Time\n\nNo observations recorded."
 
     lines = [
         "## Statistics Over Time\n",
-        "| Tick | Gini | Total Output | Mean Wealth | Median Wealth |",
-        "| --- | --- | --- | --- | --- |",
+        "| Tick | Gini | Pareto | Total Output | Mean Wealth | Median Wealth |",
+        "| --- | --- | --- | --- | --- | --- |",
     ]
 
     for entry in history:
         lines.append(
             f"| {entry.tick} "
             f"| {entry.gini:.4f} "
+            f"| {entry.pareto_score:.4f} "
             f"| {entry.total_output:.2f} "
             f"| {entry.mean_wealth:.2f} "
             f"| {entry.median_wealth:.2f} |"

--- a/tests/test_pareto.py
+++ b/tests/test_pareto.py
@@ -1,0 +1,147 @@
+"""Tests for Pareto efficiency computation."""
+
+from __future__ import annotations
+
+import math
+
+import pytest
+
+from emergent_constitution.models.agent import AgentState, UtilityParams, ValueVector
+from emergent_constitution.models.constitution import Constitution
+from emergent_constitution.observer import (
+    _compute_utility,
+    compute_pareto_efficiency,
+    observe_tick,
+)
+
+
+def _make_agent(
+    agent_id: str,
+    wealth: float,
+    productivity: float = 10.0,
+    alpha: float = 0.5,
+    beta: float = 0.3,
+    gamma: float = 0.2,
+) -> AgentState:
+    """Helper to create an agent with given wealth and utility params."""
+    return AgentState(
+        id=agent_id,
+        wealth=wealth,
+        productivity=productivity,
+        utility_params=UtilityParams(alpha=alpha, beta=beta, gamma=gamma),
+        value_vector=ValueVector(equality=0.5, liberty=0.5),
+    )
+
+
+class TestComputeUtility:
+    """Tests for _compute_utility helper."""
+
+    def test_known_values(self):
+        """Cobb-Douglas utility matches hand-computed result."""
+        agent = _make_agent("a0", wealth=100.0, alpha=0.5, beta=0.3, gamma=0.2)
+        # U = 100^0.5 * 1.0^0.3 * 10^0.2 = 10 * 1 * 10^0.2
+        expected = math.pow(100.0, 0.5) * math.pow(1.0, 0.3) * math.pow(10.0, 0.2)
+        result = _compute_utility(agent, 100.0, 10.0)
+        assert result == pytest.approx(expected, rel=1e-9)
+
+    def test_zero_wealth_positive_alpha(self):
+        """Zero wealth with positive alpha exponent returns 0."""
+        agent = _make_agent("a0", wealth=0.0, alpha=0.5, beta=0.3, gamma=0.2)
+        assert _compute_utility(agent, 0.0, 10.0) == 0.0
+
+    def test_zero_public_goods_positive_gamma(self):
+        """Zero public goods with positive gamma exponent returns 0."""
+        agent = _make_agent("a0", wealth=100.0, alpha=0.5, beta=0.3, gamma=0.2)
+        assert _compute_utility(agent, 100.0, 0.0) == 0.0
+
+    def test_utility_increases_with_wealth(self):
+        """Utility is monotonically increasing in wealth (alpha > 0)."""
+        agent = _make_agent("a0", wealth=50.0, alpha=0.5, beta=0.3, gamma=0.2)
+        u_low = _compute_utility(agent, 50.0, 10.0)
+        u_high = _compute_utility(agent, 100.0, 10.0)
+        assert u_high > u_low
+
+
+class TestParetoEfficiency:
+    """Tests for compute_pareto_efficiency."""
+
+    def test_pareto_equal_agents(self):
+        """All-equal wealth should produce score of 1.0 (already optimal).
+
+        With equal wealth, any transfer would decrease the donor's utility
+        due to diminishing returns (concave Cobb-Douglas).
+        """
+        agents = [_make_agent(f"a{i}", wealth=100.0) for i in range(5)]
+        score = compute_pareto_efficiency(agents)
+        assert score == pytest.approx(1.0)
+
+    def test_pareto_extreme_inequality(self):
+        """Heterogeneous preferences with extreme inequality -> sub-optimal.
+
+        When a wealthy agent has alpha=0 (does not value wealth at all) and
+        poor agents have high alpha, a transfer costs the donor nothing in
+        utility but strictly improves the recipient's utility. This is a
+        strict Pareto improvement.
+        """
+        # Rich agent doesn't care about wealth at all (alpha=0.0).
+        agents = [_make_agent("rich", wealth=10000.0, alpha=0.0, beta=0.5, gamma=0.5)]
+        # Poor agents strongly value wealth (alpha=0.8).
+        agents += [
+            _make_agent(f"poor_{i}", wealth=1.0, alpha=0.8, beta=0.1, gamma=0.1) for i in range(9)
+        ]
+        score = compute_pareto_efficiency(agents)
+        # Transfers from the rich agent to any poor agent are Pareto-improving.
+        assert score < 1.0
+
+    def test_pareto_moderate_inequality(self):
+        """Some inequality should produce score between 0 and 1."""
+        agents = [
+            _make_agent("a0", wealth=200.0),
+            _make_agent("a1", wealth=100.0),
+            _make_agent("a2", wealth=50.0),
+            _make_agent("a3", wealth=25.0),
+        ]
+        score = compute_pareto_efficiency(agents)
+        assert 0.0 <= score <= 1.0
+
+    def test_pareto_single_agent(self):
+        """Single agent is trivially Pareto optimal."""
+        agents = [_make_agent("a0", wealth=100.0)]
+        score = compute_pareto_efficiency(agents)
+        assert score == pytest.approx(1.0)
+
+    def test_pareto_empty_list(self):
+        """Empty agent list returns 1.0."""
+        score = compute_pareto_efficiency([])
+        assert score == pytest.approx(1.0)
+
+    def test_pareto_score_bounded(self):
+        """Score is always in [0, 1]."""
+        agents = [_make_agent(f"a{i}", wealth=float(i * 100)) for i in range(10)]
+        score = compute_pareto_efficiency(agents)
+        assert 0.0 <= score <= 1.0
+
+
+class TestParetoInHistory:
+    """Tests that pareto_score appears in HistoryEntry after observe_tick."""
+
+    def test_pareto_in_history(self):
+        """observe_tick includes pareto_score in the returned HistoryEntry."""
+        agents = [
+            _make_agent("a0", wealth=100.0),
+            _make_agent("a1", wealth=100.0),
+            _make_agent("a2", wealth=100.0),
+        ]
+        entry = observe_tick(1, agents, Constitution(), None)
+        # Equal agents: score should be 1.0
+        assert hasattr(entry, "pareto_score")
+        assert entry.pareto_score == pytest.approx(1.0)
+
+    def test_pareto_in_history_inequality(self):
+        """observe_tick computes a meaningful pareto_score for unequal agents."""
+        agents = [
+            _make_agent("rich", wealth=10000.0),
+            _make_agent("poor", wealth=0.0),
+        ]
+        entry = observe_tick(1, agents, Constitution(), None)
+        assert 0.0 <= entry.pareto_score <= 1.0


### PR DESCRIPTION
## Summary
- Implement `compute_pareto_efficiency` scoring based on pairwise Pareto improvement checks
- Uses Cobb-Douglas utility function (`_compute_utility`) to evaluate transfer benefits
- Add `pareto_score` field to `HistoryEntry` model and include in reporter output

## Test plan
- [x] 12 new tests covering utility computation, Pareto scoring, and history integration
- [x] All 198 tests pass
- [x] Ruff check and format clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)