### PR TITLE
feat: implement ObserverV2 with DSGE-HA statistics

### DIFF
--- a/src/emergent_constitution/lead.py
+++ b/src/emergent_constitution/lead.py
@@ -44,13 +44,11 @@ from emergent_constitution.models.decisions import (
 from emergent_constitution.models.firm import FirmState
 from emergent_constitution.models.history import (
     HistoryEntry,
-    HistoryEntryV2,
     PeriodState,
     SimulationOutput,
     SimulationOutputV2,
-    WelfareSummary,
 )
-from emergent_constitution.models.household import HouseholdState, OccupationalRole
+from emergent_constitution.models.household import HouseholdState
 from emergent_constitution.models.market import MarketState
 from emergent_constitution.models.proposal import (
     ConstitutionalProposal,
@@ -62,7 +60,7 @@ from emergent_constitution.models.proposal import (
 from emergent_constitution.models.shocks import ShockState
 from emergent_constitution.models.tick import TickState
 from emergent_constitution.numerical_solver import NumericalSolver
-from emergent_constitution.observer import observe_tick
+from emergent_constitution.observer import ObserverV2, observe_tick
 from emergent_constitution.rng import SimulationRNG
 from emergent_constitution.shock_generators import (
     draw_aggregate_tfp,
@@ -463,10 +461,10 @@ class LeadV2:
                 transition_matrix=period_state.shocks.transition_matrix,
             )
 
-        # Observation history
-        self.history: list[HistoryEntryV2] = []
-        self._prev_constitution: ConstitutionV2 | None = None
-        self._cumulative_welfare: float = 0.0
+        # Observer (REQ-030, REQ-031, REQ-032)
+        self.observer = ObserverV2(config)
+        # Convenience alias — shares same list object as observer.history
+        self.history = self.observer.history
 
         # Track log(A) for aggregate TFP AR(1) process
         self._prev_log_a: float = 0.0  # log(1.0) = 0
@@ -495,22 +493,7 @@ class LeadV2:
 
         log.info("simulation_v2.completed", total_periods=self.config.max_periods)
 
-        # Compute welfare summary
-        total_welfare = sum(h.realized_utility for h in self.period_state.households)
-        welfare_summary = WelfareSummary(
-            llm_total_welfare=total_welfare,
-            benchmark_total_welfare=None,
-        )
-
-        return SimulationOutputV2(
-            constitution=self.period_state.constitution.model_copy(deep=True),
-            history=list(self.history),
-            final_households=[h.model_copy(deep=True) for h in self.period_state.households],
-            final_firms=[f.model_copy(deep=True) for f in self.period_state.firms],
-            welfare_summary=welfare_summary,
-            seed=self.config.seed,
-            total_periods=self.config.max_periods,
-        )
+        return self.observer.finalize(self.period_state)
 
     def _advance_period(self, t: int) -> PeriodState:
         """Execute one period with the 9-step lifecycle.
@@ -1097,6 +1080,9 @@ class LeadV2:
     ) -> None:
         """Record observation statistics at observer_interval periods.
 
+        Delegates to ObserverV2.observe() which computes all REQ-030 stats
+        including Pareto efficiency, Gini, welfare, firm stats, etc.
+
         Args:
             t: Current period.
             households: Updated household states.
@@ -1109,79 +1095,18 @@ class LeadV2:
         if t % self.config.observer_interval != 0:
             return
 
-        wealths = [h.wealth for h in households]
-        n = len(wealths)
-
-        # Gini coefficient
-        gini = self._compute_gini(wealths)
-
-        # Wealth statistics
-        mean_wealth = sum(wealths) / n if n > 0 else 0.0
-        sorted_w = sorted(wealths)
-        median_wealth = (
-            (sorted_w[n // 2] if n % 2 == 1 else (sorted_w[n // 2 - 1] + sorted_w[n // 2]) / 2.0)
-            if n > 0
-            else 0.0
-        )
-
-        # Wealth quantiles [p10, p25, p50, p75, p90]
-        quantiles = []
-        if n > 0:
-            for p in [0.10, 0.25, 0.50, 0.75, 0.90]:
-                idx = min(int(p * n), n - 1)
-                quantiles.append(sorted_w[idx])
-
-        # Unemployment rate
-        unemployed = sum(1 for h in households if h.role == OccupationalRole.UNEMPLOYED)
-        unemployment_rate = unemployed / n if n > 0 else 0.0
-
-        # Firm statistics
-        num_firms = len(firms)
-        mean_firm_size = (
-            sum(len(f.worker_ids) for f in firms) / num_firms if num_firms > 0 else 0.0
-        )
-        total_rd = sum(f.rd_spend for f in firms)
-
-        # Social welfare
-        social_welfare = sum(h.realized_utility for h in households)
-        self._cumulative_welfare += social_welfare
-
-        # Rule changes
-        rule_changes = self._detect_rule_changes_v2(self._prev_constitution, constitution)
-
-        entry = HistoryEntryV2(
+        period_snapshot = PeriodState(
             period=t,
-            gini=gini,
-            pareto_score=1.0,  # Full Pareto computation deferred to Observer (Task 12)
-            aggregate_output=market.aggregate_output,
-            aggregate_consumption=sum(h.consumption for h in households),
-            aggregate_investment=market.aggregate_investment,
-            mean_wealth=mean_wealth,
-            median_wealth=median_wealth,
-            wealth_quantiles=quantiles,
-            unemployment_rate=unemployment_rate,
-            num_active_firms=num_firms,
-            mean_firm_size=mean_firm_size,
-            aggregate_rd_spend=total_rd,
-            social_welfare=social_welfare,
-            cumulative_welfare=self._cumulative_welfare,
-            wage=market.wage,
-            interest_rate=market.interest_rate,
-            rule_changes=rule_changes,
-            constitution_snapshot=constitution.model_copy(deep=True),
+            households=households,
+            firms=firms,
+            market=market,
+            shocks=self.period_state.shocks,
+            constitution=constitution,
+            proposals=proposals,
+            votes=votes,
         )
 
-        self.history.append(entry)
-        self._prev_constitution = constitution.model_copy(deep=True)
-
-        log.info(
-            "observation_v2.recorded",
-            period=t,
-            gini=round(gini, 4),
-            mean_wealth=round(mean_wealth, 2),
-            social_welfare=round(social_welfare, 2),
-            num_firms=num_firms,
-        )
+        self.observer.observe(period_snapshot)
 
     # ------------------------------------------------------------------
     # Helpers
@@ -1202,72 +1127,3 @@ class LeadV2:
         # Use the rate from the first tax rule
         rate = tax_rules[0].parameters.get("rate", 0.0)
         return max(0.0, min(1.0, float(rate)))
-
-    @staticmethod
-    def _compute_gini(values: list[float]) -> float:
-        """Compute the Gini coefficient of a list of values.
-
-        Args:
-            values: Non-negative values.
-
-        Returns:
-            Gini in [0, 1].
-        """
-        n = len(values)
-        if n < 2:
-            return 0.0
-        sorted_v = sorted(values)
-        total = sum(sorted_v)
-        if total <= 0.0:
-            return 0.0
-        # Gini = (2 * sum(i * x_i) - (n+1) * sum(x_i)) / (n * sum(x_i))
-        weighted_sum = sum((i + 1) * v for i, v in enumerate(sorted_v))
-        return (2.0 * weighted_sum - (n + 1) * total) / (n * total)
-
-    @staticmethod
-    def _detect_rule_changes_v2(
-        prev: ConstitutionV2 | None,
-        current: ConstitutionV2,
-    ) -> list[str]:
-        """Detect changes between two v2 constitutions.
-
-        Args:
-            prev: Previous constitution, or None for first observation.
-            current: Current constitution.
-
-        Returns:
-            List of human-readable change descriptions.
-        """
-        if prev is None:
-            return []
-
-        changes: list[str] = []
-
-        # Check voting rule change
-        if prev.voting_rule != current.voting_rule:
-            changes.append(f"voting_rule: {prev.voting_rule} -> {current.voting_rule}")
-
-        # Check for added, modified, and removed rules
-        prev_names = set(prev.rules.keys())
-        curr_names = set(current.rules.keys())
-
-        for name in curr_names - prev_names:
-            changes.append(f"rule added: {name}")
-
-        for name in prev_names - curr_names:
-            changes.append(f"rule removed: {name}")
-
-        for name in prev_names & curr_names:
-            prev_rule = prev.rules[name]
-            curr_rule = current.rules[name]
-            if prev_rule.parameters != curr_rule.parameters:
-                changes.append(
-                    f"rule modified: {name} params "
-                    f"{prev_rule.parameters} -> {curr_rule.parameters}"
-                )
-            if prev_rule.version != curr_rule.version:
-                changes.append(
-                    f"rule version: {name} v{prev_rule.version} -> v{curr_rule.version}"
-                )
-
-        return changes

--- a/src/emergent_constitution/observer.py
+++ b/src/emergent_constitution/observer.py
@@ -1,7 +1,11 @@
 """Observer/Statistician — aggregate statistics and rule-change detection.
 
-All functions are pure: they take state and return results without
-mutating any inputs.
+v1 functions (observe_tick, compute_pareto_efficiency, etc.) retained for
+backward compatibility.
+
+v2 class (ObserverV2) implements REQ-030, REQ-031, REQ-032 with full DSGE-HA
+statistics: Gini, Pareto score, Y/C/I aggregates, wealth quantiles,
+unemployment, firm stats, social welfare, cumulative discounted welfare.
 """
 
 from __future__ import annotations
@@ -9,10 +13,22 @@ from __future__ import annotations
 import math
 import statistics
 
+import structlog
+
 from emergent_constitution.citizen import compute_gini
+from emergent_constitution.config import SimulationConfigV2
 from emergent_constitution.models.agent import AgentState
-from emergent_constitution.models.constitution import Constitution
-from emergent_constitution.models.history import HistoryEntry
+from emergent_constitution.models.constitution import Constitution, ConstitutionV2
+from emergent_constitution.models.history import (
+    HistoryEntry,
+    HistoryEntryV2,
+    PeriodState,
+    SimulationOutputV2,
+    WelfareSummary,
+)
+from emergent_constitution.models.household import HouseholdState, OccupationalRole
+
+log = structlog.get_logger()
 
 # Small transfer amount used to test for Pareto improvements.
 _TRANSFER_DELTA = 1.0
@@ -152,7 +168,7 @@ def _detect_rule_changes(
         current: Constitution at the current observation.
 
     Returns:
-        List of human-readable change descriptions, e.g. ``"tax_rate: 0.0 → 0.25"``.
+        List of human-readable change descriptions, e.g. ``"tax_rate: 0.0 -> 0.25"``.
     """
     if prev is None:
         return []
@@ -162,6 +178,327 @@ def _detect_rule_changes(
         old_val = getattr(prev, field_name)
         new_val = getattr(current, field_name)
         if old_val != new_val:
-            changes.append(f"{field_name}: {old_val} → {new_val}")
+            changes.append(f"{field_name}: {old_val} \u2192 {new_val}")
+
+    return changes
+
+
+# ============================================================================
+# v2 Observer (DSGE-HA statistics)
+# ============================================================================
+
+# Epsilon guard for utility computation.
+_EPSILON = 1e-10
+
+
+class ObserverV2:
+    """Computes and records macro statistics for the DSGE-HA simulation.
+
+    Tracks observation history and cumulative welfare across periods.
+    Used by LeadV2 to record statistics at each observer_interval.
+
+    Args:
+        config: Simulation configuration.
+
+    Implements REQ-030, REQ-031, REQ-032.
+    """
+
+    def __init__(self, config: SimulationConfigV2) -> None:
+        self.config = config
+        self.history: list[HistoryEntryV2] = []
+        self._cumulative_welfare: float = 0.0
+        self._prev_constitution: ConstitutionV2 | None = None
+
+    def observe(
+        self,
+        period_state: PeriodState,
+        prev_constitution: ConstitutionV2 | None = None,
+    ) -> HistoryEntryV2:
+        """Compute all REQ-030 statistics and record a history entry.
+
+        Args:
+            period_state: Complete state for this period.
+            prev_constitution: Constitution at the previous observation, or
+                None for the first observation. If provided, overrides the
+                internally tracked previous constitution.
+
+        Returns:
+            HistoryEntryV2 with all computed statistics.
+        """
+        if prev_constitution is not None:
+            self._prev_constitution = prev_constitution
+
+        households = period_state.households
+        firms = period_state.firms
+        market = period_state.market
+        constitution = period_state.constitution
+        t = period_state.period
+
+        wealths = [h.wealth for h in households]
+        n = len(wealths)
+
+        # Gini coefficient
+        gini = self._compute_gini(wealths)
+
+        # Pareto efficiency score
+        pareto_score = self.compute_pareto_efficiency_v2(households)
+
+        # Wealth statistics
+        mean_wealth = sum(wealths) / n if n > 0 else 0.0
+        sorted_w = sorted(wealths)
+        if n > 0:
+            if n % 2 == 1:
+                median_wealth = sorted_w[n // 2]
+            else:
+                median_wealth = (sorted_w[n // 2 - 1] + sorted_w[n // 2]) / 2.0
+        else:
+            median_wealth = 0.0
+
+        # Wealth quantiles [p10, p25, p50, p75, p90]
+        quantiles = self._compute_quantiles(sorted_w)
+
+        # Unemployment rate
+        unemployed = sum(1 for h in households if h.role == OccupationalRole.UNEMPLOYED)
+        unemployment_rate = unemployed / n if n > 0 else 0.0
+
+        # Firm statistics
+        num_firms = len(firms)
+        mean_firm_size = (
+            sum(len(f.worker_ids) for f in firms) / num_firms if num_firms > 0 else 0.0
+        )
+        total_rd = sum(f.rd_spend for f in firms)
+
+        # Social welfare (REQ-031)
+        social_welfare = sum(h.realized_utility for h in households)
+
+        # Cumulative discounted welfare
+        avg_beta = sum(h.utility_params.beta_discount for h in households) / n if n > 0 else 0.95
+        self._cumulative_welfare = self._cumulative_welfare * avg_beta + social_welfare
+
+        # Rule changes
+        rule_changes = detect_rule_changes_v2(self._prev_constitution, constitution)
+
+        entry = HistoryEntryV2(
+            period=t,
+            gini=gini,
+            pareto_score=pareto_score,
+            aggregate_output=market.aggregate_output,
+            aggregate_consumption=sum(h.consumption for h in households),
+            aggregate_investment=market.aggregate_investment,
+            mean_wealth=mean_wealth,
+            median_wealth=median_wealth,
+            wealth_quantiles=quantiles,
+            unemployment_rate=unemployment_rate,
+            num_active_firms=num_firms,
+            mean_firm_size=mean_firm_size,
+            aggregate_rd_spend=total_rd,
+            social_welfare=social_welfare,
+            cumulative_welfare=self._cumulative_welfare,
+            wage=market.wage,
+            interest_rate=market.interest_rate,
+            rule_changes=rule_changes,
+            constitution_snapshot=constitution.model_copy(deep=True),
+        )
+
+        self.history.append(entry)
+        self._prev_constitution = constitution.model_copy(deep=True)
+
+        log.info(
+            "observation_v2.recorded",
+            period=t,
+            gini=round(gini, 4),
+            mean_wealth=round(mean_wealth, 2),
+            social_welfare=round(social_welfare, 2),
+            pareto_score=round(pareto_score, 4),
+            num_firms=num_firms,
+        )
+
+        return entry
+
+    def finalize(self, period_state: PeriodState) -> SimulationOutputV2:
+        """Produce final simulation output per REQ-032.
+
+        Args:
+            period_state: The final period state.
+
+        Returns:
+            SimulationOutputV2 with constitution, history, final states,
+            and welfare summary.
+        """
+        total_welfare = sum(e.social_welfare for e in self.history)
+
+        welfare_summary = WelfareSummary(
+            llm_total_welfare=total_welfare,
+            benchmark_total_welfare=None,
+            per_agent_comparison=None,
+        )
+
+        return SimulationOutputV2(
+            constitution=period_state.constitution.model_copy(deep=True),
+            history=list(self.history),
+            final_households=[h.model_copy(deep=True) for h in period_state.households],
+            final_firms=[f.model_copy(deep=True) for f in period_state.firms],
+            welfare_summary=welfare_summary,
+            seed=self.config.seed,
+            total_periods=period_state.period,
+        )
+
+    @staticmethod
+    def compute_pareto_efficiency_v2(
+        households: list[HouseholdState],
+    ) -> float:
+        """Estimate Pareto efficiency for v2 households.
+
+        Tests each pair: can a small consumption transfer from the richer
+        to the poorer improve the recipient without harming the donor?
+
+        Uses the household's actual utility parameters and realized
+        consumption/leisure context.
+
+        Args:
+            households: List of household states.
+
+        Returns:
+            Score in [0, 1]. 1.0 means no Pareto improvements found.
+        """
+        n = len(households)
+        if n <= 1:
+            return 1.0
+
+        pairs_checked = 0
+        improvements_found = 0
+
+        for i in range(n):
+            for j in range(i + 1, n):
+                hi, hj = households[i], households[j]
+                if hi.wealth >= hj.wealth:
+                    h_rich, h_poor = hi, hj
+                else:
+                    h_rich, h_poor = hj, hi
+
+                if h_rich.wealth < _TRANSFER_DELTA:
+                    pairs_checked += 1
+                    continue
+
+                u_rich_before = _compute_utility_v2(h_rich, h_rich.consumption)
+                u_poor_before = _compute_utility_v2(h_poor, h_poor.consumption)
+                u_rich_after = _compute_utility_v2(
+                    h_rich,
+                    max(h_rich.consumption - _TRANSFER_DELTA, 0.0),
+                )
+                u_poor_after = _compute_utility_v2(h_poor, h_poor.consumption + _TRANSFER_DELTA)
+
+                pairs_checked += 1
+                if u_poor_after > u_poor_before and u_rich_after >= u_rich_before:
+                    improvements_found += 1
+
+        if pairs_checked == 0:
+            return 1.0
+        return 1.0 - (improvements_found / pairs_checked)
+
+    @staticmethod
+    def _compute_gini(values: list[float]) -> float:
+        """Compute the Gini coefficient of a list of values.
+
+        Args:
+            values: Non-negative values.
+
+        Returns:
+            Gini in [0, 1].
+        """
+        n = len(values)
+        if n < 2:
+            return 0.0
+        sorted_v = sorted(values)
+        total = sum(sorted_v)
+        if total <= 0.0:
+            return 0.0
+        weighted_sum = sum((i + 1) * v for i, v in enumerate(sorted_v))
+        return (2.0 * weighted_sum - (n + 1) * total) / (n * total)
+
+    @staticmethod
+    def _compute_quantiles(sorted_values: list[float]) -> list[float]:
+        """Compute wealth quantiles [p10, p25, p50, p75, p90].
+
+        Args:
+            sorted_values: Sorted list of values.
+
+        Returns:
+            List of 5 quantile values, or empty if input is empty.
+        """
+        n = len(sorted_values)
+        if n == 0:
+            return []
+        quantiles = []
+        for p in [0.10, 0.25, 0.50, 0.75, 0.90]:
+            idx = min(int(p * n), n - 1)
+            quantiles.append(sorted_values[idx])
+        return quantiles
+
+
+def _compute_utility_v2(
+    household: HouseholdState,
+    consumption: float,
+) -> float:
+    """Compute Cobb-Douglas utility for a v2 household.
+
+    Uses actual leisure and a minimal public goods guard.
+
+    Args:
+        household: Household state with utility params and leisure.
+        consumption: Consumption level to evaluate.
+
+    Returns:
+        Utility value >= 0.
+    """
+    c = max(consumption, _EPSILON)
+    lei = max(household.leisure, _EPSILON)
+    g = _EPSILON  # Public goods not available at pair level; use guard
+    p = household.utility_params
+    try:
+        return (c**p.alpha) * (lei**p.beta) * (g**p.gamma)
+    except (ValueError, OverflowError):
+        return 0.0
+
+
+def detect_rule_changes_v2(
+    prev: ConstitutionV2 | None,
+    current: ConstitutionV2,
+) -> list[str]:
+    """Detect changes between two v2 constitutions.
+
+    Args:
+        prev: Previous constitution, or None for first observation.
+        current: Current constitution.
+
+    Returns:
+        List of human-readable change descriptions.
+    """
+    if prev is None:
+        return []
+
+    changes: list[str] = []
+
+    if prev.voting_rule != current.voting_rule:
+        changes.append(f"voting_rule: {prev.voting_rule} -> {current.voting_rule}")
+
+    prev_names = set(prev.rules.keys())
+    curr_names = set(current.rules.keys())
+
+    for name in sorted(curr_names - prev_names):
+        changes.append(f"rule added: {name}")
+
+    for name in sorted(prev_names - curr_names):
+        changes.append(f"rule removed: {name}")
+
+    for name in sorted(prev_names & curr_names):
+        prev_rule = prev.rules[name]
+        curr_rule = current.rules[name]
+        if prev_rule.parameters != curr_rule.parameters:
+            changes.append(
+                f"rule modified: {name} params {prev_rule.parameters} -> {curr_rule.parameters}"
+            )
+        if prev_rule.version != curr_rule.version:
+            changes.append(f"rule version: {name} v{prev_rule.version} -> v{curr_rule.version}")
 
     return changes

--- a/tests/test_lead_v2.py
+++ b/tests/test_lead_v2.py
@@ -20,6 +20,7 @@ from emergent_constitution.models.decisions import EconomicDecision, Entrepreneu
 from emergent_constitution.models.history import HistoryEntryV2, PeriodState, SimulationOutputV2
 from emergent_constitution.models.market import MarketState
 from emergent_constitution.models.shocks import ShockState
+from emergent_constitution.observer import ObserverV2, detect_rule_changes_v2
 
 # ============================================================================
 # Fixtures
@@ -101,7 +102,7 @@ class TestLeadV2Init:
         assert len(lead.period_state.households) == 20
         assert lead.period_state.period == 0
         assert lead.history == []
-        assert lead._cumulative_welfare == 0.0
+        assert lead.observer._cumulative_welfare == 0.0
 
     def test_llm_mode_initialization(self, mock_config: SimulationConfigV2) -> None:
         """LLM mode: LLM engine created, solver also created as fallback."""
@@ -445,21 +446,21 @@ class TestGiniComputation:
 
     def test_perfect_equality(self) -> None:
         """All equal values -> Gini = 0."""
-        gini = LeadV2._compute_gini([100.0, 100.0, 100.0, 100.0])
+        gini = ObserverV2._compute_gini([100.0, 100.0, 100.0, 100.0])
         assert gini == pytest.approx(0.0, abs=1e-10)
 
     def test_maximal_inequality(self) -> None:
         """One agent has everything -> Gini near 1."""
-        gini = LeadV2._compute_gini([0.0, 0.0, 0.0, 1000.0])
+        gini = ObserverV2._compute_gini([0.0, 0.0, 0.0, 1000.0])
         assert gini > 0.5
 
     def test_single_agent(self) -> None:
         """Single agent -> Gini = 0."""
-        assert LeadV2._compute_gini([100.0]) == 0.0
+        assert ObserverV2._compute_gini([100.0]) == 0.0
 
     def test_empty_list(self) -> None:
         """Empty list -> Gini = 0."""
-        assert LeadV2._compute_gini([]) == 0.0
+        assert ObserverV2._compute_gini([]) == 0.0
 
 
 class TestRuleChangeDetection:
@@ -471,7 +472,7 @@ class TestRuleChangeDetection:
 
         c1 = create_default_constitution()
         c2 = c1.model_copy(deep=True)
-        changes = LeadV2._detect_rule_changes_v2(c1, c2)
+        changes = detect_rule_changes_v2(c1, c2)
         assert changes == []
 
     def test_first_observation(self) -> None:
@@ -479,7 +480,7 @@ class TestRuleChangeDetection:
         from emergent_constitution.models.constitution import create_default_constitution
 
         c = create_default_constitution()
-        changes = LeadV2._detect_rule_changes_v2(None, c)
+        changes = detect_rule_changes_v2(None, c)
         assert changes == []
 
     def test_rule_parameter_change(self) -> None:
@@ -489,7 +490,7 @@ class TestRuleChangeDetection:
         c1 = create_default_constitution()
         c2 = c1.model_copy(deep=True)
         c2.rules["flat_tax"].parameters["rate"] = 0.25
-        changes = LeadV2._detect_rule_changes_v2(c1, c2)
+        changes = detect_rule_changes_v2(c1, c2)
         assert any("flat_tax" in c and "modified" in c for c in changes)
 
     def test_rule_added(self) -> None:
@@ -508,7 +509,7 @@ class TestRuleChangeDetection:
             parameters={"minimum_wage": 5.0},
             description="Test rule",
         )
-        changes = LeadV2._detect_rule_changes_v2(c1, c2)
+        changes = detect_rule_changes_v2(c1, c2)
         assert any("new_rule" in c and "added" in c for c in changes)
 
     def test_rule_removed(self) -> None:
@@ -518,5 +519,5 @@ class TestRuleChangeDetection:
         c1 = create_default_constitution()
         c2 = c1.model_copy(deep=True)
         del c2.rules["private_property"]
-        changes = LeadV2._detect_rule_changes_v2(c1, c2)
+        changes = detect_rule_changes_v2(c1, c2)
         assert any("private_property" in c and "removed" in c for c in changes)

--- a/tests/test_observer_v2.py
+++ b/tests/test_observer_v2.py
@@ -1,0 +1,507 @@
+"""Unit tests for ObserverV2 — DSGE-HA statistics and welfare computation.
+
+Tests: Gini, quantiles, unemployment rate, firm stats, social welfare,
+cumulative discounted welfare, Pareto efficiency, rule change detection,
+finalize output.
+
+Traceability: REQ-030, REQ-031, REQ-032.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from emergent_constitution.config import SimulationConfigV2
+from emergent_constitution.models.constitution import (
+    ConstitutionalRule,
+    ConstitutionV2,
+    RuleType,
+    create_default_constitution,
+)
+from emergent_constitution.models.firm import FirmState
+from emergent_constitution.models.history import PeriodState, SimulationOutputV2
+from emergent_constitution.models.household import (
+    HouseholdState,
+    OccupationalRole,
+    UtilityParams,
+    ValueVector,
+)
+from emergent_constitution.models.market import MarketState
+from emergent_constitution.models.shocks import ShockState
+from emergent_constitution.observer import (
+    ObserverV2,
+    detect_rule_changes_v2,
+)
+
+# ============================================================================
+# Helpers
+# ============================================================================
+
+
+def _make_household(
+    agent_id: str,
+    wealth: float = 100.0,
+    consumption: float = 10.0,
+    leisure: float = 0.3,
+    realized_utility: float = 1.0,
+    role: OccupationalRole = OccupationalRole.WORKER,
+    productivity: float = 1.0,
+    beta_discount: float = 0.95,
+) -> HouseholdState:
+    return HouseholdState(
+        id=agent_id,
+        wealth=wealth,
+        productivity=productivity,
+        productivity_index=0,
+        utility_params=UtilityParams(alpha=0.5, beta=0.3, gamma=0.2, beta_discount=beta_discount),
+        value_vector=ValueVector(equality=0.5, liberty=0.5),
+        role=role,
+        consumption=consumption,
+        leisure=leisure,
+        labor_supply=1.0 - leisure,
+        realized_utility=realized_utility,
+    )
+
+
+def _make_firm(
+    firm_id: str,
+    worker_ids: list[str] | None = None,
+    rd_spend: float = 0.0,
+) -> FirmState:
+    return FirmState(
+        id=firm_id,
+        owner_id="agent_0000",
+        capital=100.0,
+        labor_demand=1.0,
+        tfp=1.0,
+        worker_ids=worker_ids or [],
+        rd_spend=rd_spend,
+    )
+
+
+def _make_period_state(
+    period: int = 1,
+    households: list[HouseholdState] | None = None,
+    firms: list[FirmState] | None = None,
+    constitution: ConstitutionV2 | None = None,
+) -> PeriodState:
+    if households is None:
+        households = [_make_household(f"agent_{i:04d}") for i in range(5)]
+    if constitution is None:
+        constitution = create_default_constitution()
+    return PeriodState(
+        period=period,
+        households=households,
+        firms=firms or [],
+        market=MarketState(
+            wage=1.0,
+            interest_rate=0.04,
+            aggregate_output=100.0,
+            aggregate_investment=20.0,
+        ),
+        shocks=ShockState(
+            productivity_grid=[0.5, 1.0, 1.5],
+            transition_matrix=[[0.9, 0.1, 0.0], [0.1, 0.8, 0.1], [0.0, 0.1, 0.9]],
+        ),
+        constitution=constitution,
+    )
+
+
+@pytest.fixture
+def config() -> SimulationConfigV2:
+    return SimulationConfigV2(
+        num_agents=20,
+        max_periods=3,
+        seed=42,
+        use_llm=True,
+        llm_provider="mock",
+        benchmark_mode=False,
+        observer_interval=1,
+        proposal_interval=5,
+    )
+
+
+# ============================================================================
+# Tests: ObserverV2.observe() — Gini
+# ============================================================================
+
+
+class TestObserverV2Gini:
+    """Test Gini coefficient computation via observe()."""
+
+    def test_equal_wealth_gini_zero(self, config: SimulationConfigV2) -> None:
+        """All equal wealth -> Gini = 0."""
+        households = [_make_household(f"a{i}", wealth=100.0) for i in range(5)]
+        ps = _make_period_state(households=households)
+        observer = ObserverV2(config)
+        entry = observer.observe(ps)
+        assert entry.gini == pytest.approx(0.0, abs=1e-10)
+
+    def test_unequal_wealth_gini_positive(self, config: SimulationConfigV2) -> None:
+        """Unequal wealth -> Gini > 0."""
+        households = [_make_household(f"a{i}", wealth=float(i * 100)) for i in range(5)]
+        ps = _make_period_state(households=households)
+        observer = ObserverV2(config)
+        entry = observer.observe(ps)
+        assert entry.gini > 0.0
+
+    def test_single_agent_gini_zero(self, config: SimulationConfigV2) -> None:
+        """Single agent -> Gini = 0."""
+        households = [_make_household("a0")]
+        ps = _make_period_state(households=households)
+        observer = ObserverV2(config)
+        entry = observer.observe(ps)
+        assert entry.gini == 0.0
+
+
+# ============================================================================
+# Tests: Wealth quantiles
+# ============================================================================
+
+
+class TestObserverV2Quantiles:
+    """Test wealth quantile computation."""
+
+    def test_quantiles_five_agents(self, config: SimulationConfigV2) -> None:
+        """Five agents with distinct wealth -> 5 quantile values."""
+        households = [_make_household(f"a{i}", wealth=float((i + 1) * 100)) for i in range(5)]
+        ps = _make_period_state(households=households)
+        observer = ObserverV2(config)
+        entry = observer.observe(ps)
+        assert len(entry.wealth_quantiles) == 5
+        # Quantiles should be non-decreasing
+        for k in range(len(entry.wealth_quantiles) - 1):
+            assert entry.wealth_quantiles[k] <= entry.wealth_quantiles[k + 1]
+
+    def test_quantiles_equal_wealth(self, config: SimulationConfigV2) -> None:
+        """All equal wealth -> all quantiles equal."""
+        households = [_make_household(f"a{i}", wealth=50.0) for i in range(10)]
+        ps = _make_period_state(households=households)
+        observer = ObserverV2(config)
+        entry = observer.observe(ps)
+        assert all(q == pytest.approx(50.0) for q in entry.wealth_quantiles)
+
+
+# ============================================================================
+# Tests: Unemployment rate
+# ============================================================================
+
+
+class TestObserverV2Unemployment:
+    """Test unemployment rate computation."""
+
+    def test_no_unemployed(self, config: SimulationConfigV2) -> None:
+        """All workers -> unemployment = 0."""
+        households = [_make_household(f"a{i}", role=OccupationalRole.WORKER) for i in range(5)]
+        ps = _make_period_state(households=households)
+        observer = ObserverV2(config)
+        entry = observer.observe(ps)
+        assert entry.unemployment_rate == pytest.approx(0.0)
+
+    def test_half_unemployed(self, config: SimulationConfigV2) -> None:
+        """Half unemployed -> rate = 0.5."""
+        households = [_make_household(f"a{i}", role=OccupationalRole.WORKER) for i in range(5)] + [
+            _make_household(f"u{i}", role=OccupationalRole.UNEMPLOYED) for i in range(5)
+        ]
+        ps = _make_period_state(households=households)
+        observer = ObserverV2(config)
+        entry = observer.observe(ps)
+        assert entry.unemployment_rate == pytest.approx(0.5)
+
+    def test_all_unemployed(self, config: SimulationConfigV2) -> None:
+        """All unemployed -> rate = 1.0."""
+        households = [_make_household(f"a{i}", role=OccupationalRole.UNEMPLOYED) for i in range(5)]
+        ps = _make_period_state(households=households)
+        observer = ObserverV2(config)
+        entry = observer.observe(ps)
+        assert entry.unemployment_rate == pytest.approx(1.0)
+
+
+# ============================================================================
+# Tests: Firm statistics
+# ============================================================================
+
+
+class TestObserverV2FirmStats:
+    """Test firm statistics computation."""
+
+    def test_no_firms(self, config: SimulationConfigV2) -> None:
+        """No firms -> zero stats."""
+        ps = _make_period_state(firms=[])
+        observer = ObserverV2(config)
+        entry = observer.observe(ps)
+        assert entry.num_active_firms == 0
+        assert entry.mean_firm_size == 0.0
+        assert entry.aggregate_rd_spend == 0.0
+
+    def test_firm_count_and_size(self, config: SimulationConfigV2) -> None:
+        """Two firms with workers -> correct count and mean size."""
+        firms = [
+            _make_firm("f0", worker_ids=["a0", "a1", "a2"]),
+            _make_firm("f1", worker_ids=["a3"]),
+        ]
+        ps = _make_period_state(firms=firms)
+        observer = ObserverV2(config)
+        entry = observer.observe(ps)
+        assert entry.num_active_firms == 2
+        assert entry.mean_firm_size == pytest.approx(2.0)  # (3+1)/2
+
+    def test_aggregate_rd_spend(self, config: SimulationConfigV2) -> None:
+        """Total R&D aggregated across firms."""
+        firms = [
+            _make_firm("f0", rd_spend=10.0),
+            _make_firm("f1", rd_spend=25.0),
+        ]
+        ps = _make_period_state(firms=firms)
+        observer = ObserverV2(config)
+        entry = observer.observe(ps)
+        assert entry.aggregate_rd_spend == pytest.approx(35.0)
+
+
+# ============================================================================
+# Tests: Social welfare and cumulative welfare (REQ-031)
+# ============================================================================
+
+
+class TestObserverV2Welfare:
+    """Test social welfare and cumulative discounted welfare."""
+
+    def test_social_welfare_sum(self, config: SimulationConfigV2) -> None:
+        """Social welfare = sum of realized utilities."""
+        households = [_make_household(f"a{i}", realized_utility=float(i + 1)) for i in range(5)]
+        ps = _make_period_state(households=households)
+        observer = ObserverV2(config)
+        entry = observer.observe(ps)
+        assert entry.social_welfare == pytest.approx(15.0)  # 1+2+3+4+5
+
+    def test_cumulative_welfare_discounting(self, config: SimulationConfigV2) -> None:
+        """Cumulative welfare applies discount factor across periods."""
+        households = [
+            _make_household(f"a{i}", realized_utility=10.0, beta_discount=0.9) for i in range(5)
+        ]
+        observer = ObserverV2(config)
+
+        ps1 = _make_period_state(period=1, households=households)
+        entry1 = observer.observe(ps1)
+        # First period: cumulative = 0 * 0.9 + 50 = 50
+        assert entry1.cumulative_welfare == pytest.approx(50.0)
+
+        ps2 = _make_period_state(period=2, households=households)
+        entry2 = observer.observe(ps2)
+        # Second period: cumulative = 50 * 0.9 + 50 = 95
+        assert entry2.cumulative_welfare == pytest.approx(95.0)
+
+    def test_zero_utility(self, config: SimulationConfigV2) -> None:
+        """All zero utilities -> welfare = 0."""
+        households = [_make_household(f"a{i}", realized_utility=0.0) for i in range(5)]
+        ps = _make_period_state(households=households)
+        observer = ObserverV2(config)
+        entry = observer.observe(ps)
+        assert entry.social_welfare == pytest.approx(0.0)
+
+
+# ============================================================================
+# Tests: Pareto efficiency
+# ============================================================================
+
+
+class TestObserverV2Pareto:
+    """Test v2 Pareto efficiency computation."""
+
+    def test_single_agent_is_pareto_efficient(self) -> None:
+        """Single agent is always Pareto efficient."""
+        households = [_make_household("a0")]
+        score = ObserverV2.compute_pareto_efficiency_v2(households)
+        assert score == 1.0
+
+    def test_equal_wealth_is_efficient(self) -> None:
+        """Equal wealth -> high Pareto score."""
+        households = [_make_household(f"a{i}", wealth=100.0, consumption=10.0) for i in range(5)]
+        score = ObserverV2.compute_pareto_efficiency_v2(households)
+        assert score >= 0.8  # Nearly or fully efficient
+
+    def test_score_in_valid_range(self) -> None:
+        """Pareto score always in [0, 1]."""
+        households = [
+            _make_household(f"a{i}", wealth=float(i * 100), consumption=float(i * 10))
+            for i in range(10)
+        ]
+        score = ObserverV2.compute_pareto_efficiency_v2(households)
+        assert 0.0 <= score <= 1.0
+
+
+# ============================================================================
+# Tests: Market data in observation
+# ============================================================================
+
+
+class TestObserverV2MarketData:
+    """Test market prices and aggregates in observation."""
+
+    def test_wage_and_interest_rate(self, config: SimulationConfigV2) -> None:
+        """Wage and interest rate from MarketState are recorded."""
+        ps = _make_period_state()
+        observer = ObserverV2(config)
+        entry = observer.observe(ps)
+        assert entry.wage == 1.0
+        assert entry.interest_rate == 0.04
+
+    def test_aggregate_output_and_investment(self, config: SimulationConfigV2) -> None:
+        """Y and I from MarketState are recorded."""
+        ps = _make_period_state()
+        observer = ObserverV2(config)
+        entry = observer.observe(ps)
+        assert entry.aggregate_output == 100.0
+        assert entry.aggregate_investment == 20.0
+
+    def test_aggregate_consumption(self, config: SimulationConfigV2) -> None:
+        """Aggregate consumption = sum of household consumption."""
+        households = [_make_household(f"a{i}", consumption=float(i + 1)) for i in range(5)]
+        ps = _make_period_state(households=households)
+        observer = ObserverV2(config)
+        entry = observer.observe(ps)
+        assert entry.aggregate_consumption == pytest.approx(15.0)
+
+
+# ============================================================================
+# Tests: Rule change detection (v2)
+# ============================================================================
+
+
+class TestDetectRuleChangesV2:
+    """Test detect_rule_changes_v2 function."""
+
+    def test_no_prev(self) -> None:
+        """First observation -> empty changes."""
+        c = create_default_constitution()
+        assert detect_rule_changes_v2(None, c) == []
+
+    def test_no_changes(self) -> None:
+        """Identical constitutions -> no changes."""
+        c1 = create_default_constitution()
+        c2 = c1.model_copy(deep=True)
+        assert detect_rule_changes_v2(c1, c2) == []
+
+    def test_rule_added(self) -> None:
+        """Adding a rule is detected."""
+        c1 = create_default_constitution()
+        c2 = c1.model_copy(deep=True)
+        c2.rules["new_rule"] = ConstitutionalRule(
+            name="new_rule",
+            rule_type=RuleType.MARKET_REGULATION,
+            parameters={"min_wage": 5.0},
+            description="New test rule",
+        )
+        changes = detect_rule_changes_v2(c1, c2)
+        assert any("rule added" in c for c in changes)
+
+    def test_rule_removed(self) -> None:
+        """Removing a rule is detected."""
+        c1 = create_default_constitution()
+        c2 = c1.model_copy(deep=True)
+        del c2.rules["private_property"]
+        changes = detect_rule_changes_v2(c1, c2)
+        assert any("rule removed" in c for c in changes)
+
+    def test_parameter_change(self) -> None:
+        """Changing rule parameters is detected."""
+        c1 = create_default_constitution()
+        c2 = c1.model_copy(deep=True)
+        c2.rules["flat_tax"].parameters["rate"] = 0.3
+        changes = detect_rule_changes_v2(c1, c2)
+        assert any("rule modified" in c for c in changes)
+
+
+# ============================================================================
+# Tests: finalize() — REQ-032
+# ============================================================================
+
+
+class TestObserverV2Finalize:
+    """Test finalize() produces correct SimulationOutputV2."""
+
+    def test_finalize_output_type(self, config: SimulationConfigV2) -> None:
+        """finalize() returns SimulationOutputV2."""
+        observer = ObserverV2(config)
+        ps = _make_period_state(period=3)
+        observer.observe(ps)
+        output = observer.finalize(ps)
+        assert isinstance(output, SimulationOutputV2)
+
+    def test_finalize_includes_history(self, config: SimulationConfigV2) -> None:
+        """finalize() includes all recorded history entries."""
+        observer = ObserverV2(config)
+        for t in range(1, 4):
+            ps = _make_period_state(period=t)
+            observer.observe(ps)
+        ps_final = _make_period_state(period=3)
+        output = observer.finalize(ps_final)
+        assert len(output.history) == 3
+
+    def test_finalize_welfare_summary(self, config: SimulationConfigV2) -> None:
+        """finalize() welfare summary has total welfare from all periods."""
+        households = [_make_household(f"a{i}", realized_utility=10.0) for i in range(5)]
+        observer = ObserverV2(config)
+        for t in range(1, 4):
+            ps = _make_period_state(period=t, households=households)
+            observer.observe(ps)
+        output = observer.finalize(_make_period_state(period=3, households=households))
+        # 5 agents * 10 utility * 3 periods = 150
+        assert output.welfare_summary.llm_total_welfare == pytest.approx(150.0)
+
+    def test_finalize_seed_and_periods(self, config: SimulationConfigV2) -> None:
+        """finalize() records seed from config and period from state."""
+        observer = ObserverV2(config)
+        ps = _make_period_state(period=5)
+        observer.observe(ps)
+        output = observer.finalize(ps)
+        assert output.seed == config.seed
+        assert output.total_periods == 5
+
+    def test_finalize_deep_copies(self, config: SimulationConfigV2) -> None:
+        """finalize() output is independent of input state."""
+        observer = ObserverV2(config)
+        ps = _make_period_state(period=1)
+        observer.observe(ps)
+        output = observer.finalize(ps)
+
+        # Mutate original household
+        ps.households[0].wealth = 999999.0
+        assert output.final_households[0].wealth != 999999.0
+
+
+# ============================================================================
+# Tests: History accumulation
+# ============================================================================
+
+
+class TestObserverV2History:
+    """Test that history entries accumulate correctly."""
+
+    def test_history_length(self, config: SimulationConfigV2) -> None:
+        """Each observe() appends one entry."""
+        observer = ObserverV2(config)
+        for t in range(1, 6):
+            ps = _make_period_state(period=t)
+            observer.observe(ps)
+        assert len(observer.history) == 5
+
+    def test_history_period_numbers(self, config: SimulationConfigV2) -> None:
+        """History entries have correct period numbers."""
+        observer = ObserverV2(config)
+        for t in [1, 3, 5]:
+            ps = _make_period_state(period=t)
+            observer.observe(ps)
+        periods = [e.period for e in observer.history]
+        assert periods == [1, 3, 5]
+
+    def test_constitution_snapshot_is_deep_copy(self, config: SimulationConfigV2) -> None:
+        """Constitution snapshot in entry is independent of original."""
+        c = create_default_constitution()
+        ps = _make_period_state(constitution=c)
+        observer = ObserverV2(config)
+        entry = observer.observe(ps)
+
+        # Mutate original constitution
+        c.rules["flat_tax"].parameters["rate"] = 0.99
+        assert entry.constitution_snapshot.rules["flat_tax"].parameters.get("rate") != 0.99


### PR DESCRIPTION
## Summary

Closes #25

- Extract observer logic from LeadV2 into dedicated `ObserverV2` class implementing REQ-030, REQ-031, REQ-032
- `observe()` computes all per-period statistics: Gini, Pareto score, Y/C/I aggregates, wealth quantiles, unemployment, firm stats, social welfare, cumulative discounted welfare, wage, interest rate, rule changes
- `finalize()` produces `SimulationOutputV2` with welfare summary
- LeadV2 delegates to `self.observer` instead of inline computation; removes redundant helper methods
- 33 new unit tests in `test_observer_v2.py`; all 767 tests pass

## Files Changed

- `src/emergent_constitution/observer.py` — Added `ObserverV2` class, `detect_rule_changes_v2()`, `_compute_utility_v2()`
- `src/emergent_constitution/lead.py` — Integrated `ObserverV2`, removed redundant `_compute_gini()` and `_detect_rule_changes_v2()`
- `tests/test_lead_v2.py` — Updated references to moved methods
- `tests/test_observer_v2.py` — New: 33 unit tests across 10 test classes

## Test plan

- [x] All 33 new observer_v2 tests pass
- [x] All 33 existing lead_v2 tests pass (updated references)
- [x] All 13 v1 observer tests pass (backward compatible)
- [x] Full suite: 767 passed, 0 failed
- [x] Ruff lint and format clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)