### PR TITLE
feat: expand reporter for v2 DSGE-HA output

### DIFF
--- a/src/emergent_constitution/reporter.py
+++ b/src/emergent_constitution/reporter.py
@@ -1,5 +1,11 @@
 """Reporter — human-readable simulation report generation.
 
+v1 functions (generate_report, etc.) retained for backward compatibility.
+
+v2 functions (generate_report_v2, generate_json_v2) handle SimulationOutputV2
+with DSGE-HA data: firm summary, welfare summary, expanded statistics,
+wealth quantiles, and full JSON serialization.
+
 All functions are pure: they take SimulationOutput and return strings
 without performing any I/O.
 """
@@ -11,8 +17,15 @@ import statistics
 from emergent_constitution.citizen import compute_gini
 from emergent_constitution.coalition import compute_coalition_stats
 from emergent_constitution.models.agent import AgentState
-from emergent_constitution.models.constitution import Constitution
-from emergent_constitution.models.history import HistoryEntry, SimulationOutput
+from emergent_constitution.models.constitution import Constitution, ConstitutionV2
+from emergent_constitution.models.history import (
+    HistoryEntry,
+    HistoryEntryV2,
+    SimulationOutput,
+    SimulationOutputV2,
+    WelfareSummary,
+)
+from emergent_constitution.models.household import HouseholdState
 from emergent_constitution.observer import compute_pareto_efficiency
 
 
@@ -211,6 +224,298 @@ def _format_statistics_evolution(history: list[HistoryEntry]) -> str:
             f"| {entry.mean_wealth:.2f} "
             f"| {entry.median_wealth:.2f} "
             f"| {entry.num_coalitions} |"
+        )
+
+    return "\n".join(lines)
+
+
+# ============================================================================
+# v2 Reporter (DSGE-HA output)
+# ============================================================================
+
+
+def generate_report_v2(output: SimulationOutputV2) -> str:
+    """Generate a full Markdown report from v2 simulation output.
+
+    Args:
+        output: Complete v2 simulation output.
+
+    Returns:
+        Human-readable Markdown report string.
+    """
+    sections = [
+        _format_simulation_summary_v2(output),
+        _format_final_constitution_v2(output.constitution),
+        _format_wealth_distribution_v2(output.final_households),
+        _format_firm_summary(output),
+        _format_welfare_summary(output.welfare_summary),
+        _format_constitutional_timeline_v2(output.history),
+        _format_statistics_evolution_v2(output.history),
+    ]
+    return "\n\n".join(sections) + "\n"
+
+
+def generate_json_v2(output: SimulationOutputV2) -> str:
+    """Serialize v2 simulation output to JSON.
+
+    Args:
+        output: Complete v2 simulation output.
+
+    Returns:
+        JSON string with all v2 data (constitution, history, households,
+        firms, welfare summary, seed, total_periods).
+    """
+    return output.model_dump_json(indent=2)
+
+
+def _format_simulation_summary_v2(output: SimulationOutputV2) -> str:
+    """Format the header section with v2 simulation metadata.
+
+    Args:
+        output: Complete v2 simulation output.
+
+    Returns:
+        Markdown header with seed, periods, household count, firm count.
+    """
+    return (
+        "# The Emergent Constitution — Simulation Report (v2)\n\n"
+        f"- **Seed:** {output.seed}\n"
+        f"- **Total periods:** {output.total_periods}\n"
+        f"- **Number of households:** {len(output.final_households)}\n"
+        f"- **Number of firms:** {len(output.final_firms)}"
+    )
+
+
+def _format_final_constitution_v2(constitution: ConstitutionV2) -> str:
+    """Format the final v2 constitutional rules as a table.
+
+    Args:
+        constitution: The final ConstitutionV2 object.
+
+    Returns:
+        Markdown section listing all active rules with type and parameters.
+    """
+    lines = [
+        "## Final Constitution\n",
+        f"**Voting rule:** {constitution.voting_rule}\n",
+        "| Rule | Type | Parameters |",
+        "| --- | --- | --- |",
+    ]
+
+    for name, rule in sorted(constitution.rules.items()):
+        params_str = ", ".join(f"{k}={v}" for k, v in rule.parameters.items())
+        lines.append(f"| {name} | {rule.rule_type.value} | {params_str} |")
+
+    return "\n".join(lines)
+
+
+def _format_wealth_distribution_v2(households: list[HouseholdState]) -> str:
+    """Format wealth distribution statistics for v2 households.
+
+    Args:
+        households: List of final HouseholdState objects.
+
+    Returns:
+        Markdown section with distribution stats, quantiles, and quintiles.
+    """
+    if not households:
+        return "## Wealth Distribution\n\nNo households in simulation."
+
+    wealths = [h.wealth for h in households]
+    n = len(wealths)
+    mean = statistics.mean(wealths)
+    median = statistics.median(wealths)
+    stdev = statistics.stdev(wealths) if n >= 2 else "N/A"
+    stdev_str = f"{stdev:.2f}" if isinstance(stdev, float) else stdev
+
+    # Compute Gini using same algorithm as ObserverV2
+    sorted_w = sorted(wealths)
+    total = sum(sorted_w)
+    if total > 0 and n >= 2:
+        weighted_sum = sum((i + 1) * v for i, v in enumerate(sorted_w))
+        gini = (2.0 * weighted_sum - (n + 1) * total) / (n * total)
+    else:
+        gini = 0.0
+
+    lines = [
+        "## Wealth Distribution\n",
+        f"- **Min:** {min(wealths):.2f}",
+        f"- **Max:** {max(wealths):.2f}",
+        f"- **Mean:** {mean:.2f}",
+        f"- **Median:** {median:.2f}",
+        f"- **Std dev:** {stdev_str}",
+        f"- **Gini coefficient:** {gini:.4f}",
+    ]
+
+    # Wealth quantiles [p10, p25, p50, p75, p90]
+    if n >= 5:
+        quantile_labels = ["p10", "p25", "p50", "p75", "p90"]
+        quantile_pcts = [0.10, 0.25, 0.50, 0.75, 0.90]
+        lines.append("\n### Wealth Quantiles\n")
+        lines.append("| Quantile | Value |")
+        lines.append("| --- | --- |")
+        for label, p in zip(quantile_labels, quantile_pcts, strict=True):
+            idx = min(int(p * n), n - 1)
+            lines.append(f"| {label} | {sorted_w[idx]:.2f} |")
+
+    # Quintile breakdown
+    if n >= 5:
+        q_size = n // 5
+        lines.append("\n### Quintile Breakdown\n")
+        lines.append("| Quintile | Mean Wealth |")
+        lines.append("| --- | --- |")
+        for q in range(5):
+            start = q * q_size
+            end = (q + 1) * q_size if q < 4 else n
+            q_mean = statistics.mean(sorted_w[start:end])
+            label = ["Bottom 20%", "20-40%", "40-60%", "60-80%", "Top 20%"][q]
+            lines.append(f"| {label} | {q_mean:.2f} |")
+
+    return "\n".join(lines)
+
+
+def _format_firm_summary(output: SimulationOutputV2) -> str:
+    """Format a summary of active firms.
+
+    Args:
+        output: Complete v2 simulation output.
+
+    Returns:
+        Markdown section with firm count, mean size, total R&D, and table.
+    """
+    firms = output.final_firms
+    if not firms:
+        return "## Firm Summary\n\nNo active firms at end of simulation."
+
+    num_firms = len(firms)
+    total_workers = sum(len(f.worker_ids) for f in firms)
+    mean_size = total_workers / num_firms
+    total_rd = sum(f.rd_spend for f in firms)
+    total_output = sum(f.output for f in firms)
+    total_profit = sum(f.profit for f in firms)
+
+    lines = [
+        "## Firm Summary\n",
+        f"- **Number of firms:** {num_firms}",
+        f"- **Total workers employed:** {total_workers}",
+        f"- **Mean firm size:** {mean_size:.1f}",
+        f"- **Total R&D spending:** {total_rd:.2f}",
+        f"- **Total firm output:** {total_output:.2f}",
+        f"- **Total firm profit:** {total_profit:.2f}",
+        "",
+        "| Firm | Owner | Workers | Capital | TFP | Output | Profit | R&D |",
+        "| --- | --- | --- | --- | --- | --- | --- | --- |",
+    ]
+
+    for f in firms:
+        lines.append(
+            f"| {f.id} | {f.owner_id} | {len(f.worker_ids)} "
+            f"| {f.capital:.2f} | {f.tfp:.4f} "
+            f"| {f.output:.2f} | {f.profit:.2f} | {f.rd_spend:.2f} |"
+        )
+
+    return "\n".join(lines)
+
+
+def _format_welfare_summary(welfare: WelfareSummary) -> str:
+    """Format the welfare comparison summary.
+
+    Args:
+        welfare: WelfareSummary with LLM and optional benchmark totals.
+
+    Returns:
+        Markdown section with welfare comparison.
+    """
+    lines = [
+        "## Welfare Summary\n",
+        f"- **LLM total welfare:** {welfare.llm_total_welfare:.4f}",
+    ]
+
+    if welfare.benchmark_total_welfare is not None:
+        lines.append(f"- **Benchmark total welfare:** {welfare.benchmark_total_welfare:.4f}")
+        if welfare.benchmark_total_welfare > 0:
+            ratio = welfare.llm_total_welfare / welfare.benchmark_total_welfare
+            lines.append(f"- **LLM / Benchmark ratio:** {ratio:.4f}")
+
+    if welfare.per_agent_comparison is not None:
+        lines.append("\n### Per-Agent Comparison\n")
+        lines.append("| Agent | LLM Welfare | Benchmark Welfare |")
+        lines.append("| --- | --- | --- |")
+        for agent_id, data in sorted(welfare.per_agent_comparison.items()):
+            llm_w = data.get("llm", 0.0)
+            bench_w = data.get("benchmark", 0.0)
+            lines.append(f"| {agent_id} | {llm_w:.4f} | {bench_w:.4f} |")
+
+    return "\n".join(lines)
+
+
+def _format_constitutional_timeline_v2(history: list[HistoryEntryV2]) -> str:
+    """Format a chronological timeline of v2 constitutional changes.
+
+    Args:
+        history: List of HistoryEntryV2 objects.
+
+    Returns:
+        Markdown section with rule changes by period.
+    """
+    if not history:
+        return "## Constitutional Timeline\n\nNo observations recorded."
+
+    changes_found = False
+    lines = ["## Constitutional Timeline\n"]
+
+    for entry in history:
+        if entry.rule_changes:
+            changes_found = True
+            lines.append(f"**Period {entry.period}:**")
+            for change in entry.rule_changes:
+                lines.append(f"- {change}")
+
+    if not changes_found:
+        lines.append("No constitutional changes during the simulation.")
+
+    return "\n".join(lines)
+
+
+def _format_statistics_evolution_v2(history: list[HistoryEntryV2]) -> str:
+    """Format a table showing how key statistics evolved over time.
+
+    Args:
+        history: List of HistoryEntryV2 objects.
+
+    Returns:
+        Markdown table with all key DSGE-HA statistics per period.
+    """
+    if not history:
+        return "## Statistics Over Time\n\nNo observations recorded."
+
+    lines = [
+        "## Statistics Over Time\n",
+        (
+            "| Period | Gini | Pareto | Output | Consumption"
+            " | Investment | Mean Wealth | Median Wealth"
+            " | Unemployment | Firms | Welfare | Cum. Welfare"
+            " | Wage | Rate |"
+        ),
+        "| --- " * 14 + "|",
+    ]
+
+    for e in history:
+        lines.append(
+            f"| {e.period} "
+            f"| {e.gini:.4f} "
+            f"| {e.pareto_score:.4f} "
+            f"| {e.aggregate_output:.2f} "
+            f"| {e.aggregate_consumption:.2f} "
+            f"| {e.aggregate_investment:.2f} "
+            f"| {e.mean_wealth:.2f} "
+            f"| {e.median_wealth:.2f} "
+            f"| {e.unemployment_rate:.4f} "
+            f"| {e.num_active_firms} "
+            f"| {e.social_welfare:.2f} "
+            f"| {e.cumulative_welfare:.2f} "
+            f"| {e.wage:.4f} "
+            f"| {e.interest_rate:.4f} |"
         )
 
     return "\n".join(lines)

--- a/tests/test_reporter_v2.py
+++ b/tests/test_reporter_v2.py
@@ -1,0 +1,538 @@
+"""Tests for the v2 reporter module."""
+
+from __future__ import annotations
+
+import json
+
+from emergent_constitution.models.constitution import (
+    ConstitutionV2,
+    create_default_constitution,
+)
+from emergent_constitution.models.firm import FirmState
+from emergent_constitution.models.history import (
+    HistoryEntryV2,
+    SimulationOutputV2,
+    WelfareSummary,
+)
+from emergent_constitution.models.household import (
+    HouseholdState,
+    OccupationalRole,
+    UtilityParams,
+    ValueVector,
+)
+from emergent_constitution.reporter import (
+    _format_constitutional_timeline_v2,
+    _format_final_constitution_v2,
+    _format_firm_summary,
+    _format_statistics_evolution_v2,
+    _format_wealth_distribution_v2,
+    _format_welfare_summary,
+    generate_json_v2,
+    generate_report_v2,
+)
+
+
+def _make_household(
+    agent_id: str,
+    wealth: float = 100.0,
+    consumption: float = 10.0,
+    role: OccupationalRole = OccupationalRole.WORKER,
+    realized_utility: float = 5.0,
+) -> HouseholdState:
+    """Helper to create a v2 household with minimal fields."""
+    return HouseholdState(
+        id=agent_id,
+        wealth=wealth,
+        productivity=1.0,
+        productivity_index=0,
+        utility_params=UtilityParams(alpha=0.5, beta=0.3, gamma=0.2),
+        value_vector=ValueVector(equality=0.5, liberty=0.5),
+        role=role,
+        consumption=consumption,
+        leisure=0.3,
+        labor_supply=0.7,
+        realized_utility=realized_utility,
+    )
+
+
+def _make_firm(
+    firm_id: str = "firm_0000",
+    owner_id: str = "agent_0000",
+    workers: int = 3,
+    rd_spend: float = 5.0,
+    output: float = 50.0,
+    profit: float = 10.0,
+) -> FirmState:
+    """Helper to create a firm with sensible defaults."""
+    return FirmState(
+        id=firm_id,
+        owner_id=owner_id,
+        capital=100.0,
+        labor_demand=float(workers),
+        tfp=1.0,
+        worker_ids=[f"agent_{i:04d}" for i in range(workers)],
+        rd_spend=rd_spend,
+        output=output,
+        profit=profit,
+    )
+
+
+def _make_history_entry_v2(
+    period: int,
+    gini: float = 0.3,
+    aggregate_output: float = 500.0,
+    mean_wealth: float = 100.0,
+    median_wealth: float = 95.0,
+    rule_changes: list[str] | None = None,
+    social_welfare: float = 50.0,
+    cumulative_welfare: float = 100.0,
+    wage: float = 1.0,
+    interest_rate: float = 0.05,
+) -> HistoryEntryV2:
+    """Helper to create a v2 history entry."""
+    return HistoryEntryV2(
+        period=period,
+        gini=gini,
+        pareto_score=0.9,
+        aggregate_output=aggregate_output,
+        aggregate_consumption=400.0,
+        aggregate_investment=100.0,
+        mean_wealth=mean_wealth,
+        median_wealth=median_wealth,
+        wealth_quantiles=[20.0, 50.0, 95.0, 150.0, 200.0],
+        unemployment_rate=0.1,
+        num_active_firms=5,
+        mean_firm_size=4.0,
+        aggregate_rd_spend=25.0,
+        social_welfare=social_welfare,
+        cumulative_welfare=cumulative_welfare,
+        wage=wage,
+        interest_rate=interest_rate,
+        rule_changes=rule_changes or [],
+        constitution_snapshot=create_default_constitution(),
+    )
+
+
+def _make_output(
+    num_households: int = 10,
+    num_firms: int = 2,
+    num_history: int = 3,
+) -> SimulationOutputV2:
+    """Helper to create a complete v2 simulation output."""
+    households = [
+        _make_household(f"agent_{i:04d}", wealth=50.0 + i * 10) for i in range(num_households)
+    ]
+    firms = [_make_firm(f"firm_{i:04d}", f"agent_{i:04d}") for i in range(num_firms)]
+    history = [_make_history_entry_v2(period=i) for i in range(num_history)]
+    welfare = WelfareSummary(
+        llm_total_welfare=150.0,
+        benchmark_total_welfare=140.0,
+    )
+    return SimulationOutputV2(
+        constitution=create_default_constitution(),
+        history=history,
+        final_households=households,
+        final_firms=firms,
+        welfare_summary=welfare,
+        seed=42,
+        total_periods=100,
+    )
+
+
+# ============================================================================
+# generate_report_v2
+# ============================================================================
+
+
+class TestGenerateReportV2:
+    """Tests for the top-level generate_report_v2 function."""
+
+    def test_returns_nonempty_string(self):
+        output = _make_output()
+        report = generate_report_v2(output)
+        assert isinstance(report, str)
+        assert len(report) > 0
+
+    def test_contains_all_section_headers(self):
+        output = _make_output()
+        report = generate_report_v2(output)
+        assert "# The Emergent Constitution" in report
+        assert "## Final Constitution" in report
+        assert "## Wealth Distribution" in report
+        assert "## Firm Summary" in report
+        assert "## Welfare Summary" in report
+        assert "## Constitutional Timeline" in report
+        assert "## Statistics Over Time" in report
+
+    def test_contains_v2_metadata(self):
+        output = _make_output(num_households=10, num_firms=2)
+        report = generate_report_v2(output)
+        assert "**Seed:** 42" in report
+        assert "**Total periods:** 100" in report
+        assert "**Number of households:** 10" in report
+        assert "**Number of firms:** 2" in report
+
+
+# ============================================================================
+# Final Constitution (v2)
+# ============================================================================
+
+
+class TestFormatFinalConstitutionV2:
+    """Tests for v2 constitution formatting."""
+
+    def test_displays_voting_rule(self):
+        constitution = create_default_constitution()
+        text = _format_final_constitution_v2(constitution)
+        assert "majority_vote" in text
+
+    def test_displays_all_rules(self):
+        constitution = create_default_constitution()
+        text = _format_final_constitution_v2(constitution)
+        assert "flat_tax" in text
+        assert "flat_transfer" in text
+        assert "public_goods_provision" in text
+        assert "majority_vote" in text
+        assert "private_property" in text
+
+    def test_displays_rule_types(self):
+        constitution = create_default_constitution()
+        text = _format_final_constitution_v2(constitution)
+        assert "tax_schedule" in text
+        assert "transfer_program" in text
+        assert "voting_procedure" in text
+
+    def test_displays_parameters(self):
+        constitution = create_default_constitution()
+        text = _format_final_constitution_v2(constitution)
+        assert "rate=0" in text  # flat_tax rate
+        assert "threshold=0.5" in text  # majority_vote threshold
+
+    def test_empty_constitution(self):
+        constitution = ConstitutionV2()
+        text = _format_final_constitution_v2(constitution)
+        assert "Final Constitution" in text
+
+
+# ============================================================================
+# Wealth Distribution (v2)
+# ============================================================================
+
+
+class TestFormatWealthDistributionV2:
+    """Tests for v2 wealth distribution formatting."""
+
+    def test_shows_statistics(self):
+        households = [_make_household("a0", 50.0), _make_household("a1", 150.0)]
+        text = _format_wealth_distribution_v2(households)
+        assert "Min:" in text
+        assert "Max:" in text
+        assert "Mean:" in text
+        assert "Median:" in text
+        assert "Std dev:" in text
+        assert "Gini coefficient:" in text
+
+    def test_quantiles_with_enough_agents(self):
+        households = [_make_household(f"a{i}", float(i * 10)) for i in range(10)]
+        text = _format_wealth_distribution_v2(households)
+        assert "Wealth Quantiles" in text
+        assert "p10" in text
+        assert "p25" in text
+        assert "p50" in text
+        assert "p75" in text
+        assert "p90" in text
+
+    def test_quintile_breakdown_with_enough_agents(self):
+        households = [_make_household(f"a{i}", float(i * 10)) for i in range(10)]
+        text = _format_wealth_distribution_v2(households)
+        assert "Quintile Breakdown" in text
+        assert "Bottom 20%" in text
+        assert "Top 20%" in text
+
+    def test_no_quantiles_with_few_agents(self):
+        households = [_make_household(f"a{i}") for i in range(3)]
+        text = _format_wealth_distribution_v2(households)
+        assert "Wealth Quantiles" not in text
+
+    def test_empty_households(self):
+        text = _format_wealth_distribution_v2([])
+        assert "No households" in text
+
+    def test_equal_wealth_gini_zero(self):
+        households = [_make_household(f"a{i}", 100.0) for i in range(5)]
+        text = _format_wealth_distribution_v2(households)
+        assert "0.0000" in text
+
+
+# ============================================================================
+# Firm Summary
+# ============================================================================
+
+
+class TestFormatFirmSummary:
+    """Tests for firm summary formatting."""
+
+    def test_no_firms(self):
+        output = _make_output(num_firms=0)
+        text = _format_firm_summary(output)
+        assert "No active firms" in text
+
+    def test_firm_count(self):
+        output = _make_output(num_firms=3)
+        text = _format_firm_summary(output)
+        assert "Number of firms:** 3" in text
+
+    def test_firm_table_headers(self):
+        output = _make_output(num_firms=2)
+        text = _format_firm_summary(output)
+        assert "Firm" in text
+        assert "Owner" in text
+        assert "Workers" in text
+        assert "Capital" in text
+        assert "TFP" in text
+        assert "Output" in text
+        assert "Profit" in text
+        assert "R&D" in text
+
+    def test_firm_details_in_table(self):
+        output = _make_output(num_firms=1)
+        text = _format_firm_summary(output)
+        assert "firm_0000" in text
+        assert "agent_0000" in text
+
+    def test_aggregate_stats(self):
+        output = _make_output(num_firms=2)
+        text = _format_firm_summary(output)
+        assert "Total R&D spending:" in text
+        assert "Total firm output:" in text
+        assert "Total firm profit:" in text
+        assert "Mean firm size:" in text
+
+
+# ============================================================================
+# Welfare Summary
+# ============================================================================
+
+
+class TestFormatWelfareSummary:
+    """Tests for welfare summary formatting."""
+
+    def test_llm_welfare_shown(self):
+        welfare = WelfareSummary(llm_total_welfare=150.0)
+        text = _format_welfare_summary(welfare)
+        assert "LLM total welfare:" in text
+        assert "150.0000" in text
+
+    def test_benchmark_shown_when_present(self):
+        welfare = WelfareSummary(
+            llm_total_welfare=150.0,
+            benchmark_total_welfare=140.0,
+        )
+        text = _format_welfare_summary(welfare)
+        assert "Benchmark total welfare:" in text
+        assert "140.0000" in text
+        assert "LLM / Benchmark ratio:" in text
+
+    def test_no_benchmark_when_none(self):
+        welfare = WelfareSummary(llm_total_welfare=150.0)
+        text = _format_welfare_summary(welfare)
+        assert "Benchmark" not in text
+
+    def test_per_agent_comparison(self):
+        welfare = WelfareSummary(
+            llm_total_welfare=100.0,
+            per_agent_comparison={
+                "agent_0000": {"llm": 50.0, "benchmark": 45.0},
+                "agent_0001": {"llm": 50.0, "benchmark": 55.0},
+            },
+        )
+        text = _format_welfare_summary(welfare)
+        assert "Per-Agent Comparison" in text
+        assert "agent_0000" in text
+        assert "agent_0001" in text
+
+
+# ============================================================================
+# Constitutional Timeline (v2)
+# ============================================================================
+
+
+class TestFormatConstitutionalTimelineV2:
+    """Tests for v2 constitutional timeline."""
+
+    def test_no_history(self):
+        text = _format_constitutional_timeline_v2([])
+        assert "No observations recorded" in text
+
+    def test_no_changes(self):
+        history = [_make_history_entry_v2(0), _make_history_entry_v2(5)]
+        text = _format_constitutional_timeline_v2(history)
+        assert "No constitutional changes" in text
+
+    def test_with_changes(self):
+        history = [
+            _make_history_entry_v2(5, rule_changes=["rule added: carbon_tax"]),
+            _make_history_entry_v2(
+                10, rule_changes=["voting_rule: majority_vote -> supermajority"]
+            ),
+        ]
+        text = _format_constitutional_timeline_v2(history)
+        assert "Period 5" in text
+        assert "carbon_tax" in text
+        assert "Period 10" in text
+        assert "supermajority" in text
+
+
+# ============================================================================
+# Statistics Evolution (v2)
+# ============================================================================
+
+
+class TestFormatStatisticsEvolutionV2:
+    """Tests for v2 statistics evolution table."""
+
+    def test_no_history(self):
+        text = _format_statistics_evolution_v2([])
+        assert "No observations recorded" in text
+
+    def test_table_has_all_columns(self):
+        history = [_make_history_entry_v2(0)]
+        text = _format_statistics_evolution_v2(history)
+        for col in [
+            "Period",
+            "Gini",
+            "Pareto",
+            "Output",
+            "Consumption",
+            "Investment",
+            "Mean Wealth",
+            "Median Wealth",
+            "Unemployment",
+            "Firms",
+            "Welfare",
+            "Cum. Welfare",
+            "Wage",
+            "Rate",
+        ]:
+            assert col in text
+
+    def test_values_in_output(self):
+        history = [
+            _make_history_entry_v2(
+                period=5,
+                gini=0.35,
+                aggregate_output=500.0,
+                mean_wealth=100.0,
+                median_wealth=90.0,
+                social_welfare=50.0,
+                wage=1.2,
+                interest_rate=0.05,
+            ),
+        ]
+        text = _format_statistics_evolution_v2(history)
+        assert "0.3500" in text  # gini
+        assert "500.00" in text  # output
+        assert "100.00" in text  # mean wealth
+        assert "90.00" in text  # median wealth
+        assert "50.00" in text  # welfare
+        assert "1.2000" in text  # wage
+        assert "0.0500" in text  # interest rate
+
+
+# ============================================================================
+# JSON Serialization (v2)
+# ============================================================================
+
+
+class TestGenerateJsonV2:
+    """Tests for generate_json_v2."""
+
+    def test_returns_valid_json(self):
+        output = _make_output()
+        result = generate_json_v2(output)
+        parsed = json.loads(result)
+        assert isinstance(parsed, dict)
+
+    def test_has_top_level_keys(self):
+        output = _make_output()
+        result = generate_json_v2(output)
+        parsed = json.loads(result)
+        assert "constitution" in parsed
+        assert "history" in parsed
+        assert "final_households" in parsed
+        assert "final_firms" in parsed
+        assert "welfare_summary" in parsed
+        assert "seed" in parsed
+        assert "total_periods" in parsed
+
+    def test_constitution_has_rules(self):
+        output = _make_output()
+        parsed = json.loads(generate_json_v2(output))
+        assert "rules" in parsed["constitution"]
+        assert "voting_rule" in parsed["constitution"]
+
+    def test_history_entries_have_all_fields(self):
+        output = _make_output(num_history=2)
+        parsed = json.loads(generate_json_v2(output))
+        assert len(parsed["history"]) == 2
+        entry = parsed["history"][0]
+        for field in [
+            "period",
+            "gini",
+            "pareto_score",
+            "aggregate_output",
+            "aggregate_consumption",
+            "aggregate_investment",
+            "mean_wealth",
+            "median_wealth",
+            "wealth_quantiles",
+            "unemployment_rate",
+            "num_active_firms",
+            "mean_firm_size",
+            "aggregate_rd_spend",
+            "social_welfare",
+            "cumulative_welfare",
+            "wage",
+            "interest_rate",
+            "rule_changes",
+            "constitution_snapshot",
+        ]:
+            assert field in entry, f"Missing field: {field}"
+
+    def test_households_serialized(self):
+        output = _make_output(num_households=5)
+        parsed = json.loads(generate_json_v2(output))
+        assert len(parsed["final_households"]) == 5
+        h = parsed["final_households"][0]
+        assert "id" in h
+        assert "wealth" in h
+        assert "utility_params" in h
+        assert "role" in h
+
+    def test_firms_serialized(self):
+        output = _make_output(num_firms=3)
+        parsed = json.loads(generate_json_v2(output))
+        assert len(parsed["final_firms"]) == 3
+        f = parsed["final_firms"][0]
+        assert "id" in f
+        assert "owner_id" in f
+        assert "worker_ids" in f
+        assert "rd_spend" in f
+
+    def test_welfare_summary_serialized(self):
+        output = _make_output()
+        parsed = json.loads(generate_json_v2(output))
+        ws = parsed["welfare_summary"]
+        assert "llm_total_welfare" in ws
+        assert "benchmark_total_welfare" in ws
+
+    def test_roundtrip_seed(self):
+        output = _make_output()
+        parsed = json.loads(generate_json_v2(output))
+        assert parsed["seed"] == 42
+        assert parsed["total_periods"] == 100
+
+    def test_empty_firms_serialized(self):
+        output = _make_output(num_firms=0)
+        parsed = json.loads(generate_json_v2(output))
+        assert parsed["final_firms"] == []


### PR DESCRIPTION
## Summary

Closes #26

- Add `generate_report_v2()` for `SimulationOutputV2` with 7 Markdown sections: simulation summary, final constitution (extensible rules), wealth distribution (quantiles + quintiles), firm summary, welfare summary (LLM vs benchmark), constitutional timeline, and 14-column DSGE-HA statistics table
- Add `generate_json_v2()` for full JSON serialization of all v2 models (households, firms, welfare, market state)
- v1 reporter functions preserved unchanged for backward compatibility
- 38 new unit tests across 9 test classes

## Files Changed

- `src/emergent_constitution/reporter.py` — Added 7 v2 formatter functions + `generate_report_v2()` + `generate_json_v2()`
- `tests/test_reporter_v2.py` — New: 38 unit tests (Markdown sections, JSON keys, edge cases)

## Test plan

- [x] All 38 new reporter_v2 tests pass
- [x] All existing v1 reporter tests pass (backward compatible)
- [x] Full suite: 871 passed, 0 failed
- [x] Ruff lint and format clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)