### PR TITLE
feat: add v2 CLI entry point with DSGE-HA flags

### DIFF
--- a/src/emergent_constitution/__main__.py
+++ b/src/emergent_constitution/__main__.py
@@ -1,4 +1,9 @@
-"""CLI entry point — run with ``python -m emergent_constitution``."""
+"""CLI entry point — run with ``python -m emergent_constitution``.
+
+v1 functions (build_parser, run_simulation, main) retained for backward compat.
+v2 functions (build_parser_v2, run_simulation_v2, main_v2) add DSGE-HA flags
+and support --benchmark mode per REQ-035.
+"""
 
 from __future__ import annotations
 
@@ -9,10 +14,10 @@ import sys
 from pydantic import ValidationError
 
 from emergent_constitution import __version__
-from emergent_constitution.config import SimulationConfig
-from emergent_constitution.lead import Lead
+from emergent_constitution.config import SimulationConfig, SimulationConfigV2
+from emergent_constitution.lead import Lead, LeadV2
 from emergent_constitution.logging import configure_logging
-from emergent_constitution.reporter import generate_report
+from emergent_constitution.reporter import generate_json_v2, generate_report, generate_report_v2
 
 
 def build_parser() -> argparse.ArgumentParser:
@@ -80,6 +85,139 @@ def main() -> None:
 
     try:
         result = run_simulation(args)
+    except ValidationError as exc:
+        print(f"Error: invalid configuration — {exc}", file=sys.stderr)
+        sys.exit(1)
+
+    if args.output:
+        with open(args.output, "w", encoding="utf-8") as f:
+            f.write(result)
+    else:
+        print(result, end="")
+
+
+# ============================================================================
+# v2 CLI (DSGE-HA)
+# ============================================================================
+
+
+def build_parser_v2() -> argparse.ArgumentParser:
+    """Build the v2 argument parser with DSGE-HA flags.
+
+    Returns:
+        Configured ArgumentParser with all v2 CLI flags per REQ-035.
+    """
+    parser = argparse.ArgumentParser(
+        prog="emergent-constitution-v2",
+        description="The Emergent Constitution v2 — DSGE-HA political economy simulation",
+    )
+
+    # Core
+    parser.add_argument(
+        "-n", "--agents", type=int, default=50, help="Number of agents (default: 50, min: 20)"
+    )
+    parser.add_argument(
+        "-t", "--periods", type=int, default=100, help="Max periods (default: 100)"
+    )
+    parser.add_argument("-s", "--seed", type=int, default=42, help="RNG seed (default: 42)")
+
+    # Shock parameters
+    parser.add_argument("--rho-z", type=float, default=0.9, help="Idiosyncratic persistence")
+    parser.add_argument("--sigma-z", type=float, default=0.2, help="Idiosyncratic volatility")
+    parser.add_argument(
+        "--rho-A", type=float, default=0.95, dest="rho_a", help="Aggregate TFP persistence"
+    )
+    parser.add_argument(
+        "--sigma-A", type=float, default=0.01, dest="sigma_a", help="Aggregate TFP volatility"
+    )
+
+    # Production
+    parser.add_argument("--alpha", type=float, default=0.33, help="Capital share (default: 0.33)")
+    parser.add_argument(
+        "--delta", type=float, default=0.1, help="Depreciation rate (default: 0.1)"
+    )
+
+    # Household
+    parser.add_argument("--a-min", type=float, default=0.0, help="Borrowing limit (default: 0.0)")
+
+    # Intervals
+    parser.add_argument(
+        "--proposal-interval", type=int, default=5, help="Proposal interval (default: 5)"
+    )
+    parser.add_argument(
+        "--observer-interval", type=int, default=5, help="Observer interval (default: 5)"
+    )
+
+    # Execution mode
+    parser.add_argument(
+        "--benchmark", action="store_true", help="Numerical-only mode (no LLM calls)"
+    )
+
+    # LLM settings
+    parser.add_argument("--llm-provider", type=str, default="anthropic", help="LLM provider")
+    parser.add_argument(
+        "--llm-model",
+        type=str,
+        default="claude-sonnet-4-5-20250929",
+        help="LLM model ID",
+    )
+
+    # Output
+    parser.add_argument("-o", "--output", type=str, default=None, help="Output file path")
+    parser.add_argument("--json", action="store_true", dest="json_output", help="Output raw JSON")
+    parser.add_argument("-q", "--quiet", action="store_true", help="Suppress logging")
+    parser.add_argument("-V", "--version", action="version", version=f"%(prog)s {__version__}")
+
+    return parser
+
+
+def run_simulation_v2(args: argparse.Namespace) -> str:
+    """Create v2 config from CLI args, run the simulation, and format output.
+
+    Args:
+        args: Parsed CLI arguments.
+
+    Returns:
+        Formatted output string (JSON or Markdown).
+
+    Raises:
+        ValidationError: If args produce an invalid SimulationConfigV2.
+    """
+    config = SimulationConfigV2(
+        num_agents=args.agents,
+        max_periods=args.periods,
+        seed=args.seed,
+        rho_z=args.rho_z,
+        sigma_z=args.sigma_z,
+        rho_a=args.rho_a,
+        sigma_a=args.sigma_a,
+        alpha=args.alpha,
+        delta=args.delta,
+        a_min=args.a_min,
+        proposal_interval=args.proposal_interval,
+        observer_interval=args.observer_interval,
+        benchmark_mode=args.benchmark,
+        llm_provider=args.llm_provider,
+        llm_model=args.llm_model,
+    )
+    lead = LeadV2(config)
+    output = lead.run()
+
+    if args.json_output:
+        return generate_json_v2(output) + "\n"
+    return generate_report_v2(output)
+
+
+def main_v2() -> None:
+    """Parse v2 arguments, run simulation, and write output."""
+    parser = build_parser_v2()
+    args = parser.parse_args()
+
+    log_level = logging.WARNING if args.quiet else logging.INFO
+    configure_logging(level=log_level)
+
+    try:
+        result = run_simulation_v2(args)
     except ValidationError as exc:
         print(f"Error: invalid configuration — {exc}", file=sys.stderr)
         sys.exit(1)

--- a/tests/test_cli_v2.py
+++ b/tests/test_cli_v2.py
@@ -1,0 +1,259 @@
+"""Tests for the v2 CLI entry point."""
+
+from __future__ import annotations
+
+import json
+import os
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+from pydantic import ValidationError
+
+from emergent_constitution.__main__ import build_parser_v2, run_simulation_v2
+
+# Subprocess tests need PYTHONPATH to find the package under src/.
+_SRC_DIR = str(Path(__file__).resolve().parent.parent / "src")
+_SUBPROCESS_ENV = {**os.environ, "PYTHONPATH": _SRC_DIR}
+
+# Use mock LLM provider for fast tests (benchmark_mode uses VFI which is slow).
+_FAST_FLAGS = ["-n", "20", "-t", "3", "-q", "--llm-provider", "mock"]
+
+
+class TestBuildParserV2:
+    """Tests for the v2 argument parser."""
+
+    def test_default_values(self):
+        parser = build_parser_v2()
+        args = parser.parse_args([])
+        assert args.agents == 50
+        assert args.periods == 100
+        assert args.seed == 42
+        assert args.rho_z == 0.9
+        assert args.sigma_z == 0.2
+        assert args.rho_a == 0.95
+        assert args.sigma_a == 0.01
+        assert args.alpha == 0.33
+        assert args.delta == 0.1
+        assert args.a_min == 0.0
+        assert args.proposal_interval == 5
+        assert args.observer_interval == 5
+        assert args.benchmark is False
+        assert args.llm_provider == "anthropic"
+        assert args.llm_model == "claude-sonnet-4-5-20250929"
+        assert args.output is None
+        assert args.json_output is False
+        assert args.quiet is False
+
+    def test_custom_core_values(self):
+        parser = build_parser_v2()
+        args = parser.parse_args(["-n", "30", "-t", "50", "-s", "99"])
+        assert args.agents == 30
+        assert args.periods == 50
+        assert args.seed == 99
+
+    def test_shock_parameters(self):
+        parser = build_parser_v2()
+        args = parser.parse_args(["--rho-z", "0.8", "--sigma-z", "0.3"])
+        assert args.rho_z == 0.8
+        assert args.sigma_z == 0.3
+
+    def test_aggregate_shock_parameters(self):
+        parser = build_parser_v2()
+        args = parser.parse_args(["--rho-A", "0.9", "--sigma-A", "0.02"])
+        assert args.rho_a == 0.9
+        assert args.sigma_a == 0.02
+
+    def test_production_parameters(self):
+        parser = build_parser_v2()
+        args = parser.parse_args(["--alpha", "0.4", "--delta", "0.05"])
+        assert args.alpha == 0.4
+        assert args.delta == 0.05
+
+    def test_borrowing_limit(self):
+        parser = build_parser_v2()
+        args = parser.parse_args(["--a-min", "5.0"])
+        assert args.a_min == 5.0
+
+    def test_benchmark_flag(self):
+        parser = build_parser_v2()
+        args = parser.parse_args(["--benchmark"])
+        assert args.benchmark is True
+
+    def test_llm_flags(self):
+        parser = build_parser_v2()
+        args = parser.parse_args(["--llm-provider", "openai", "--llm-model", "gpt-4"])
+        assert args.llm_provider == "openai"
+        assert args.llm_model == "gpt-4"
+
+    def test_output_flags(self):
+        parser = build_parser_v2()
+        args = parser.parse_args(["--json", "-q", "-o", "out.json"])
+        assert args.json_output is True
+        assert args.quiet is True
+        assert args.output == "out.json"
+
+    def test_interval_flags(self):
+        parser = build_parser_v2()
+        args = parser.parse_args(["--proposal-interval", "3", "--observer-interval", "7"])
+        assert args.proposal_interval == 3
+        assert args.observer_interval == 7
+
+
+class TestRunSimulationV2:
+    """Tests for run_simulation_v2 (uses mock LLM for speed)."""
+
+    def test_mock_produces_markdown(self):
+        """Mock LLM mode produces Markdown output."""
+        parser = build_parser_v2()
+        args = parser.parse_args(_FAST_FLAGS)
+        result = run_simulation_v2(args)
+        assert "# The Emergent Constitution" in result
+        assert "(v2)" in result
+
+    def test_json_output_is_valid(self):
+        """JSON output is parseable and has expected keys."""
+        parser = build_parser_v2()
+        args = parser.parse_args([*_FAST_FLAGS, "--json"])
+        result = run_simulation_v2(args)
+        data = json.loads(result)
+        assert "constitution" in data
+        assert "history" in data
+        assert "final_households" in data
+        assert "final_firms" in data
+        assert "welfare_summary" in data
+        assert "seed" in data
+        assert data["seed"] == 42
+        assert data["total_periods"] == 3
+
+    def test_markdown_has_v2_sections(self):
+        """Markdown output contains v2-specific sections."""
+        parser = build_parser_v2()
+        args = parser.parse_args(_FAST_FLAGS)
+        result = run_simulation_v2(args)
+        assert "## Firm Summary" in result
+        assert "## Welfare Summary" in result
+
+    def test_deterministic_output(self):
+        """Same seed produces identical output."""
+        parser = build_parser_v2()
+        flags = [*_FAST_FLAGS, "-s", "123", "--json"]
+        args1 = parser.parse_args(flags)
+        args2 = parser.parse_args(flags)
+        result1 = run_simulation_v2(args1)
+        result2 = run_simulation_v2(args2)
+        assert result1 == result2
+
+    def test_invalid_config_raises(self):
+        """Invalid config (e.g. too few agents) raises ValidationError."""
+        parser = build_parser_v2()
+        args = parser.parse_args(["-n", "5", "-t", "3", "-q", "--llm-provider", "mock"])
+        with pytest.raises(ValidationError):
+            run_simulation_v2(args)
+
+    def test_custom_seed_in_output(self):
+        """Custom seed appears in JSON output."""
+        parser = build_parser_v2()
+        args = parser.parse_args([*_FAST_FLAGS, "-s", "999", "--json"])
+        result = run_simulation_v2(args)
+        data = json.loads(result)
+        assert data["seed"] == 999
+
+
+class TestCLIV2EndToEnd:
+    """End-to-end tests via subprocess using main_v2."""
+
+    def test_version_flag(self):
+        """--version prints the version string."""
+        result = subprocess.run(
+            [
+                sys.executable,
+                "-c",
+                "from emergent_constitution.__main__ import main_v2; main_v2()",
+                "--version",
+            ],
+            capture_output=True,
+            text=True,
+            timeout=10,
+            env=_SUBPROCESS_ENV,
+        )
+        assert result.returncode == 0
+        assert "0.1.0" in result.stdout
+
+    def test_mock_llm_e2e(self):
+        """Mock LLM produces Markdown output via subprocess."""
+        result = subprocess.run(
+            [
+                sys.executable,
+                "-c",
+                "from emergent_constitution.__main__ import main_v2; main_v2()",
+                *_FAST_FLAGS,
+            ],
+            capture_output=True,
+            text=True,
+            timeout=60,
+            env=_SUBPROCESS_ENV,
+        )
+        assert result.returncode == 0
+        assert "# The Emergent Constitution" in result.stdout
+
+    def test_json_e2e(self):
+        """--json produces valid JSON via subprocess."""
+        result = subprocess.run(
+            [
+                sys.executable,
+                "-c",
+                "from emergent_constitution.__main__ import main_v2; main_v2()",
+                *_FAST_FLAGS,
+                "--json",
+            ],
+            capture_output=True,
+            text=True,
+            timeout=60,
+            env=_SUBPROCESS_ENV,
+        )
+        assert result.returncode == 0
+        data = json.loads(result.stdout)
+        assert "constitution" in data
+
+    def test_invalid_config_exits_nonzero(self):
+        """Invalid config exits with code 1 and stderr message."""
+        result = subprocess.run(
+            [
+                sys.executable,
+                "-c",
+                "from emergent_constitution.__main__ import main_v2; main_v2()",
+                "-n",
+                "5",
+                "--llm-provider",
+                "mock",
+            ],
+            capture_output=True,
+            text=True,
+            timeout=10,
+            env=_SUBPROCESS_ENV,
+        )
+        assert result.returncode == 1
+        assert "Error" in result.stderr
+
+    def test_output_file_e2e(self, tmp_path: Path):
+        """--output flag writes to a file."""
+        out_file = tmp_path / "report_v2.md"
+        result = subprocess.run(
+            [
+                sys.executable,
+                "-c",
+                "from emergent_constitution.__main__ import main_v2; main_v2()",
+                *_FAST_FLAGS,
+                "-o",
+                str(out_file),
+            ],
+            capture_output=True,
+            text=True,
+            timeout=60,
+            env=_SUBPROCESS_ENV,
+        )
+        assert result.returncode == 0
+        content = out_file.read_text()
+        assert "# The Emergent Constitution" in content


### PR DESCRIPTION
## Summary

Closes #29

- Add `build_parser_v2()`, `run_simulation_v2()`, and `main_v2()` to `__main__.py` per REQ-035
- CLI flags: `--agents`, `--periods`, `--seed`, `--rho-z`, `--sigma-z`, `--rho-A`, `--sigma-A`, `--alpha`, `--delta`, `--a-min`, `--proposal-interval`, `--observer-interval`, `--benchmark`, `--llm-provider`, `--llm-model`, `--output`, `--json`, `--quiet`, `--version`
- `--benchmark` enables numerical-only mode (VFI solver, no LLM)
- `--llm-provider mock` enables fast mock LLM for testing
- Invalid config exits with code 1 and stderr error
- v1 CLI functions preserved for backward compatibility

## Files Changed

- `src/emergent_constitution/__main__.py` — Added v2 parser, simulation runner, main entry point
- `tests/test_cli_v2.py` — New: 21 tests (10 parser, 6 simulation, 5 E2E subprocess)

## Test plan

- [x] All 10 parser tests pass (flags, defaults, custom values)
- [x] All 6 simulation tests pass (mock LLM: markdown, JSON, determinism, validation)
- [x] All 5 E2E subprocess tests pass (version, mock LLM, JSON, invalid config, output file)
- [x] Full suite: 892 passed, 0 failed
- [x] Ruff lint and format clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Introduced v2 CLI alongside existing v1 with DSGE-HA model parameters
  * Added output options for JSON format and rendered reports
  * New configuration options for LLM settings, benchmark mode, and simulation intervals

* **Tests**
  * Added comprehensive test coverage for v2 CLI functionality and end-to-end behavior

<!-- end of auto-generated comment: release notes by coderabbit.ai -->