### PR TITLE
fix: support assignment statements in enforcement_code and quiet mode

### DIFF
--- a/src/emergent_constitution/__main__.py
+++ b/src/emergent_constitution/__main__.py
@@ -80,7 +80,7 @@ def main() -> None:
     parser = build_parser()
     args = parser.parse_args()
 
-    log_level = logging.WARNING if args.quiet else logging.INFO
+    log_level = logging.ERROR if args.quiet else logging.INFO
     configure_logging(level=log_level)
 
     try:
@@ -213,7 +213,7 @@ def main_v2() -> None:
     parser = build_parser_v2()
     args = parser.parse_args()
 
-    log_level = logging.WARNING if args.quiet else logging.INFO
+    log_level = logging.ERROR if args.quiet else logging.INFO
     configure_logging(level=log_level)
 
     try:

--- a/src/emergent_constitution/constitution_engine.py
+++ b/src/emergent_constitution/constitution_engine.py
@@ -162,10 +162,26 @@ def evaluate_enforcement_code(code: str, variables: dict[str, Any]) -> Any:
     safe_globals.update(_SAFE_MATH)
     safe_globals.update(variables)
 
+    # Try expression mode first (e.g., "income * rate")
     try:
         return eval(code, safe_globals)  # noqa: S307
+    except SyntaxError:
+        pass
     except Exception as exc:
         raise SandboxError(f"Enforcement code execution failed: {exc}") from exc
+
+    # Fall back to exec mode for assignments (e.g., "tax = income * rate")
+    local_ns: dict[str, Any] = {}
+    try:
+        exec(code, safe_globals, local_ns)  # noqa: S102
+    except Exception as exc:
+        raise SandboxError(f"Enforcement code execution failed: {exc}") from exc
+
+    # Return the first newly assigned variable, if any
+    if local_ns:
+        return next(iter(local_ns.values()))
+
+    return None
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

- **Sandbox evaluator**: `evaluate_enforcement_code()` only used `eval()`, which rejects assignment statements like `tax = income * rate`. Now tries `eval()` first, falls back to `exec()` with a local namespace for assignments, and returns the first assigned variable. Fixes the `constitution_engine.tax_code_failed` warnings that fired for every household every tick.
- **Quiet mode**: `-q`/`--quiet` set log level to `WARNING`, so warnings still showed. Changed to `ERROR` for both v1 and v2 CLI entry points.

## Test plan

- [x] 892 tests pass
- [x] Verified `evaluate_enforcement_code("tax = income * rate", ...)` returns correct value
- [x] Verified expression-style code (`"income * rate"`) still works
- [x] Verified `-q` suppresses warnings
- [x] Ruff checks pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Added support for assignment-style enforcement code definitions. Rules can now use assignment syntax (e.g., "tax = income * rate") in addition to expression-style syntax, providing greater flexibility in defining enforcement rules and calculations.

* **Improvements**
  * Reduced log output verbosity in quiet mode for cleaner, less intrusive operation when the quiet flag is enabled.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->