### PR TITLE
perf: homogeneous preferences — solve VFI once per period (~Nx speedup)

### DIFF
--- a/src/emergent_constitution/__main__.py
+++ b/src/emergent_constitution/__main__.py
@@ -152,6 +152,28 @@ def build_parser_v2() -> argparse.ArgumentParser:
     parser.add_argument(
         "--benchmark", action="store_true", help="Numerical-only mode (no LLM calls)"
     )
+    parser.add_argument(
+        "--heterogeneous",
+        action="store_true",
+        help="Use heterogeneous preferences (slower, Dirichlet-drawn per agent)",
+    )
+
+    # Utility overrides (homogeneous mode)
+    parser.add_argument(
+        "--utility-alpha", type=float, default=0.4, help="Consumption weight (default: 0.4)"
+    )
+    parser.add_argument(
+        "--utility-beta", type=float, default=0.35, help="Leisure weight (default: 0.35)"
+    )
+    parser.add_argument(
+        "--utility-gamma", type=float, default=0.25, help="Public goods weight (default: 0.25)"
+    )
+    parser.add_argument(
+        "--utility-discount",
+        type=float,
+        default=0.95,
+        help="Discount factor (default: 0.95)",
+    )
 
     # LLM settings
     parser.add_argument("--llm-provider", type=str, default="anthropic", help="LLM provider")
@@ -199,6 +221,11 @@ def run_simulation_v2(args: argparse.Namespace) -> str:
         benchmark_mode=args.benchmark,
         llm_provider=args.llm_provider,
         llm_model=args.llm_model,
+        homogeneous_preferences=not args.heterogeneous,
+        utility_alpha=args.utility_alpha,
+        utility_beta=args.utility_beta,
+        utility_gamma=args.utility_gamma,
+        utility_beta_discount=args.utility_discount,
     )
     lead = LeadV2(config)
     output = lead.run()

--- a/src/emergent_constitution/config.py
+++ b/src/emergent_constitution/config.py
@@ -93,6 +93,23 @@ class SimulationConfigV2(BaseModel):
     initial_wealth_mean: float = Field(default=100.0, gt=0.0)
     initial_wealth_std: float = Field(default=30.0, ge=0.0)
 
+    # --- Household preferences ---
+    homogeneous_preferences: bool = Field(
+        default=True, description="All agents share utility params (fast VFI path)"
+    )
+    utility_alpha: float = Field(
+        default=0.4, gt=0.0, lt=1.0, description="Consumption weight (homogeneous)"
+    )
+    utility_beta: float = Field(
+        default=0.35, gt=0.0, lt=1.0, description="Leisure weight (homogeneous)"
+    )
+    utility_gamma: float = Field(
+        default=0.25, gt=0.0, lt=1.0, description="Public goods weight (homogeneous)"
+    )
+    utility_beta_discount: float = Field(
+        default=0.95, gt=0.0, lt=1.0, description="Discount factor (homogeneous)"
+    )
+
     # --- Intervals ---
     proposal_interval: int = Field(
         default=5, ge=1, description="Constitutional proposal every K periods"
@@ -141,4 +158,18 @@ class SimulationConfigV2(BaseModel):
         """If benchmark_mode is enabled, force use_llm to False."""
         if self.benchmark_mode and self.use_llm:
             object.__setattr__(self, "use_llm", False)
+        return self
+
+    @model_validator(mode="after")
+    def _validate_homogeneous_weights(self) -> SimulationConfigV2:
+        """When homogeneous_preferences is True, utility weights must sum to ~1.0."""
+        if self.homogeneous_preferences:
+            total = self.utility_alpha + self.utility_beta + self.utility_gamma
+            if abs(total - 1.0) > 1e-6:
+                msg = (
+                    f"Homogeneous utility weights must sum to 1.0, "
+                    f"got {total:.6f} (alpha={self.utility_alpha}, "
+                    f"beta={self.utility_beta}, gamma={self.utility_gamma})"
+                )
+                raise ValueError(msg)
         return self

--- a/src/emergent_constitution/initialization.py
+++ b/src/emergent_constitution/initialization.py
@@ -166,12 +166,20 @@ def create_households(
         prod_idx = _draw_from_distribution(rng, stationary_dist)
         productivity = productivity_grid[prod_idx]
 
-        # Utility params: alpha, beta, gamma ~ Dirichlet; beta_discount ~ U(0.9, 0.99)
-        alpha, beta, gamma = _generate_dirichlet3(rng)
-        beta_discount = rng.uniform(0.9, 0.99)
-        utility_params = UtilityParamsV2(
-            alpha=alpha, beta=beta, gamma=gamma, beta_discount=beta_discount
-        )
+        # Utility params: homogeneous from config or heterogeneous Dirichlet
+        if config.homogeneous_preferences:
+            utility_params = UtilityParamsV2(
+                alpha=config.utility_alpha,
+                beta=config.utility_beta,
+                gamma=config.utility_gamma,
+                beta_discount=config.utility_beta_discount,
+            )
+        else:
+            alpha, beta, gamma = _generate_dirichlet3(rng)
+            beta_discount = rng.uniform(0.9, 0.99)
+            utility_params = UtilityParamsV2(
+                alpha=alpha, beta=beta, gamma=gamma, beta_discount=beta_discount
+            )
 
         # Value vector: random split
         eq = rng.random()

--- a/src/emergent_constitution/numerical_solver.py
+++ b/src/emergent_constitution/numerical_solver.py
@@ -283,6 +283,143 @@ class NumericalSolver:
         """Interpolate policy function value at (a, z_idx)."""
         return self._linear_interp(a, policy, z_idx)
 
+    @staticmethod
+    def _is_homogeneous(households: list[HouseholdState]) -> bool:
+        """Check if all households share identical utility parameters.
+
+        Auto-detects homogeneity without needing the config flag.
+        """
+        if not households:
+            return True
+        ref = households[0].utility_params
+        return all(
+            h.utility_params.alpha == ref.alpha
+            and h.utility_params.beta == ref.beta
+            and h.utility_params.gamma == ref.gamma
+            and h.utility_params.beta_discount == ref.beta_discount
+            for h in households[1:]
+        )
+
+    def solve_vfi_shared(
+        self,
+        alpha: float,
+        beta_param: float,
+        gamma: float,
+        beta_discount: float,
+        wage: float,
+        interest_rate: float,
+        public_goods: float,
+        tax_function: Callable[[float], float],
+        transfer: float,
+    ) -> tuple[list[list[float]], list[list[float]]]:
+        """Solve VFI once for shared preferences, returning policy grids.
+
+        Identical to the VFI loop in solve_household but parameterized on
+        explicit utility weights instead of reading from an agent. Returns the
+        full (n_a x n_z) policy grids so callers can interpolate per agent.
+
+        Returns:
+            Tuple of (policy_c, policy_l) grids, each n_a x n_z.
+        """
+
+        def utility(c: float, lei: float, g: float) -> float:
+            c = max(c, 1e-10)
+            lei = max(lei, 1e-10)
+            g = max(g, 1e-10)
+            return (c**alpha) * (lei**beta_param) * (g**gamma)
+
+        leisure_grid = [i / self.n_leisure for i in range(self.n_leisure + 1)]
+
+        # Initialize value function
+        v_old = [[0.0] * self.n_z for _ in range(self.n_a)]
+        for ai in range(self.n_a):
+            for zi in range(self.n_z):
+                a = self.a_grid[ai]
+                z_i = self.productivity_grid[zi]
+                income = wage * z_i * 1.0
+                tax = tax_function(income)
+                budget = (1.0 + interest_rate) * a + income - tax + transfer
+                c = max(budget - self.a_min, 1e-10)
+                v_old[ai][zi] = utility(c, 0.5, max(public_goods, 1e-10))
+
+        v_new = [[0.0] * self.n_z for _ in range(self.n_a)]
+        policy_c = [[0.0] * self.n_z for _ in range(self.n_a)]
+        policy_l = [[0.0] * self.n_z for _ in range(self.n_a)]
+
+        for _vfi_iter in range(self.vfi_max_iter):
+            max_diff = 0.0
+
+            for ai in range(self.n_a):
+                a = self.a_grid[ai]
+                for zi in range(self.n_z):
+                    z_i = self.productivity_grid[zi]
+
+                    best_val = -1e30
+                    best_c = 0.0
+                    best_l = 0.5
+
+                    for lei in leisure_grid:
+                        labor = 1.0 - lei
+                        income = wage * z_i * labor
+                        tax = tax_function(income)
+                        budget = (1.0 + interest_rate) * a + income - tax + transfer
+
+                        max_c = max(0.0, budget - self.a_min)
+                        if max_c <= 0.0:
+                            c = 1e-10
+                            a_prime = self.a_min
+                        else:
+                            best_c_inner = 1e-10
+                            best_val_inner = -1e30
+                            for ci in range(11):
+                                c_try = max_c * ci / 10.0
+                                c_try = max(c_try, 1e-10)
+                                a_prime = budget - c_try
+                                a_prime = max(a_prime, self.a_min)
+
+                                u_now = utility(c_try, lei, public_goods)
+                                ev = self._interpolate_ev(a_prime, zi, v_old)
+
+                                val = u_now + beta_discount * ev
+                                if val > best_val_inner:
+                                    best_val_inner = val
+                                    best_c_inner = c_try
+
+                            c = best_c_inner
+                            val_total = best_val_inner
+
+                        if max_c <= 0.0:
+                            u_now = utility(c, lei, public_goods)
+                            ev = self._interpolate_ev(self.a_min, zi, v_old)
+                            val_total = u_now + beta_discount * ev
+
+                        if val_total > best_val:
+                            best_val = val_total
+                            best_c = c
+                            best_l = lei
+
+                    v_new[ai][zi] = best_val
+                    policy_c[ai][zi] = best_c
+                    policy_l[ai][zi] = best_l
+
+                    diff = abs(v_new[ai][zi] - v_old[ai][zi])
+                    if diff > max_diff:
+                        max_diff = diff
+
+            for ai in range(self.n_a):
+                for zi in range(self.n_z):
+                    v_old[ai][zi] = v_new[ai][zi]
+
+            if max_diff < self.vfi_tolerance:
+                log.debug(
+                    "vfi_shared.converged",
+                    iterations=_vfi_iter + 1,
+                    max_diff=max_diff,
+                )
+                break
+
+        return policy_c, policy_l
+
     def solve_all(
         self,
         households: list[HouseholdState],
@@ -293,7 +430,9 @@ class NumericalSolver:
     ) -> dict[str, EconomicDecision]:
         """Solve for all households using VFI.
 
-        Extracts tax function from constitutional tax rate (flat tax).
+        When all households share identical utility parameters (auto-detected),
+        VFI is solved once and policies are interpolated per agent (~Nx speedup).
+        Otherwise falls back to per-agent solve_household.
 
         Args:
             households: List of household states.
@@ -312,15 +451,43 @@ class NumericalSolver:
             return income * constitution_tax_rate
 
         decisions: dict[str, EconomicDecision] = {}
-        for h in households:
-            decision = self.solve_household(
-                agent=h,
+
+        if self._is_homogeneous(households) and households:
+            ref = households[0].utility_params
+            log.debug(
+                "solve_all.fast_path",
+                n_agents=len(households),
+                alpha=ref.alpha,
+                beta=ref.beta,
+                gamma=ref.gamma,
+            )
+            policy_c, policy_l = self.solve_vfi_shared(
+                alpha=ref.alpha,
+                beta_param=ref.beta,
+                gamma=ref.gamma,
+                beta_discount=ref.beta_discount,
                 wage=market.wage,
                 interest_rate=market.interest_rate,
                 public_goods=public_goods,
                 tax_function=tax_function,
                 transfer=transfer,
             )
-            decisions[h.id] = decision
+            for h in households:
+                consumption = self._interpolate_policy(h.wealth, h.productivity_index, policy_c)
+                leisure = self._interpolate_policy(h.wealth, h.productivity_index, policy_l)
+                consumption = max(consumption, 0.0)
+                leisure = max(0.0, min(1.0, leisure))
+                decisions[h.id] = EconomicDecision(consumption=consumption, leisure=leisure)
+        else:
+            for h in households:
+                decision = self.solve_household(
+                    agent=h,
+                    wage=market.wage,
+                    interest_rate=market.interest_rate,
+                    public_goods=public_goods,
+                    tax_function=tax_function,
+                    transfer=transfer,
+                )
+                decisions[h.id] = decision
 
         return decisions

--- a/tests/test_numerical_solver.py
+++ b/tests/test_numerical_solver.py
@@ -377,3 +377,170 @@ class TestInternalMethods:
         func = [[1.0] * solver.n_z for _ in range(solver.n_a)]
         val = solver._linear_interp(1e6, func, 0)
         assert val == func[-1][0]
+
+
+# ============================================================================
+# _is_homogeneous tests
+# ============================================================================
+
+
+class TestIsHomogeneous:
+    def test_empty_list(self) -> None:
+        assert NumericalSolver._is_homogeneous([]) is True
+
+    def test_single_agent(self) -> None:
+        h = _make_household()
+        assert NumericalSolver._is_homogeneous([h]) is True
+
+    def test_identical_agents(self) -> None:
+        agents = [_make_household(f"agent_{i:04d}", wealth=50.0 + i * 10) for i in range(5)]
+        assert NumericalSolver._is_homogeneous(agents) is True
+
+    def test_different_alpha(self) -> None:
+        h1 = _make_household("a0", alpha=0.4, beta=0.3, gamma=0.3)
+        h2 = _make_household("a1", alpha=0.5, beta=0.2, gamma=0.3)
+        assert NumericalSolver._is_homogeneous([h1, h2]) is False
+
+    def test_different_discount(self) -> None:
+        h1 = _make_household("a0", beta_discount=0.95)
+        h2 = _make_household("a1", beta_discount=0.90)
+        assert NumericalSolver._is_homogeneous([h1, h2]) is False
+
+
+# ============================================================================
+# solve_vfi_shared tests
+# ============================================================================
+
+
+class TestSolveVfiShared:
+    def test_returns_grids(self) -> None:
+        solver, _, _ = _make_solver()
+        policy_c, policy_l = solver.solve_vfi_shared(
+            alpha=0.4,
+            beta_param=0.3,
+            gamma=0.3,
+            beta_discount=0.95,
+            wage=1.0,
+            interest_rate=0.05,
+            public_goods=1.0,
+            tax_function=_no_tax,
+            transfer=0.0,
+        )
+        assert len(policy_c) == solver.n_a
+        assert len(policy_c[0]) == solver.n_z
+        assert len(policy_l) == solver.n_a
+        assert len(policy_l[0]) == solver.n_z
+
+    def test_finite_values(self) -> None:
+        solver, _, _ = _make_solver()
+        policy_c, policy_l = solver.solve_vfi_shared(
+            alpha=0.4,
+            beta_param=0.3,
+            gamma=0.3,
+            beta_discount=0.95,
+            wage=1.0,
+            interest_rate=0.05,
+            public_goods=1.0,
+            tax_function=_no_tax,
+            transfer=0.0,
+        )
+        for ai in range(solver.n_a):
+            for zi in range(solver.n_z):
+                assert math.isfinite(policy_c[ai][zi])
+                assert math.isfinite(policy_l[ai][zi])
+
+    def test_consumption_generally_increasing_in_assets(self) -> None:
+        """Higher-asset grid points should broadly have higher consumption."""
+        solver, _, _ = _make_solver()
+        policy_c, _ = solver.solve_vfi_shared(
+            alpha=0.4,
+            beta_param=0.3,
+            gamma=0.3,
+            beta_discount=0.95,
+            wage=1.0,
+            interest_rate=0.05,
+            public_goods=1.0,
+            tax_function=_no_tax,
+            transfer=0.0,
+        )
+        for zi in range(solver.n_z):
+            # Top-quartile asset consumption > bottom-quartile
+            low_avg = sum(policy_c[ai][zi] for ai in range(5)) / 5
+            high_avg = sum(policy_c[ai][zi] for ai in range(solver.n_a - 5, solver.n_a)) / 5
+            assert high_avg > low_avg
+
+
+# ============================================================================
+# Fast path vs slow path correctness
+# ============================================================================
+
+
+class TestFastPathMatchesSlowPath:
+    def test_fast_path_matches_per_agent(self) -> None:
+        """Shared VFI + interpolation should produce same results as per-agent VFI."""
+        solver, grid, _ = _make_solver()
+        alpha, beta_param, gamma, beta_discount = 0.4, 0.3, 0.3, 0.95
+        households = [
+            _make_household(
+                f"agent_{i:04d}",
+                wealth=20.0 + i * 30,
+                productivity=grid[i % len(grid)],
+                productivity_index=i % len(grid),
+                alpha=alpha,
+                beta=beta_param,
+                gamma=gamma,
+                beta_discount=beta_discount,
+            )
+            for i in range(5)
+        ]
+        market = MarketState(wage=1.0, interest_rate=0.05)
+
+        # Fast path (solve_all auto-detects homogeneity)
+        fast_decisions = solver.solve_all(households, market, public_goods=1.0)
+
+        # Slow path (per-agent)
+        slow_decisions: dict[str, EconomicDecision] = {}
+        for h in households:
+            d = solver.solve_household(
+                h,
+                wage=1.0,
+                interest_rate=0.05,
+                public_goods=1.0,
+                tax_function=lambda income: 0.0,
+                transfer=0.0,
+            )
+            slow_decisions[h.id] = d
+
+        for h in households:
+            assert abs(fast_decisions[h.id].consumption - slow_decisions[h.id].consumption) < 1e-10
+            assert abs(fast_decisions[h.id].leisure - slow_decisions[h.id].leisure) < 1e-10
+
+    def test_heterogeneous_uses_slow_path(self) -> None:
+        """When agents differ, solve_all should still return valid results."""
+        solver, grid, _ = _make_solver()
+        households = [
+            _make_household(
+                "agent_0000",
+                wealth=100.0,
+                productivity=grid[0],
+                productivity_index=0,
+                alpha=0.4,
+                beta=0.3,
+                gamma=0.3,
+            ),
+            _make_household(
+                "agent_0001",
+                wealth=100.0,
+                productivity=grid[1],
+                productivity_index=1,
+                alpha=0.5,
+                beta=0.2,
+                gamma=0.3,
+            ),
+        ]
+        market = MarketState(wage=1.0, interest_rate=0.05)
+        decisions = solver.solve_all(households, market, public_goods=1.0)
+        assert len(decisions) == 2
+        for d in decisions.values():
+            assert d.consumption >= 0.0
+            assert 0.0 <= d.leisure <= 1.0

--- a/tests/test_v2_config.py
+++ b/tests/test_v2_config.py
@@ -194,3 +194,57 @@ class TestSimulationConfigV2Serialization:
         assert config.num_z_states == 7
         assert config.use_llm is False
         assert config.solver_method == "vfi"
+
+
+class TestHomogeneousPreferencesConfig:
+    def test_defaults(self) -> None:
+        config = SimulationConfigV2()
+        assert config.homogeneous_preferences is True
+        assert config.utility_alpha == 0.4
+        assert config.utility_beta == 0.35
+        assert config.utility_gamma == 0.25
+        assert config.utility_beta_discount == 0.95
+
+    def test_weights_sum_validated(self) -> None:
+        """Weights that don't sum to 1.0 should raise when homogeneous=True."""
+        with pytest.raises(ValidationError):
+            SimulationConfigV2(
+                homogeneous_preferences=True,
+                utility_alpha=0.5,
+                utility_beta=0.5,
+                utility_gamma=0.5,
+            )
+
+    def test_weights_not_validated_when_heterogeneous(self) -> None:
+        """When homogeneous_preferences=False, utility weights are not enforced."""
+        config = SimulationConfigV2(
+            homogeneous_preferences=False,
+            utility_alpha=0.1,
+            utility_beta=0.1,
+            utility_gamma=0.1,
+        )
+        assert config.homogeneous_preferences is False
+
+    def test_custom_weights(self) -> None:
+        config = SimulationConfigV2(
+            utility_alpha=0.5,
+            utility_beta=0.3,
+            utility_gamma=0.2,
+            utility_beta_discount=0.98,
+        )
+        assert config.utility_alpha == 0.5
+        assert config.utility_beta == 0.3
+        assert config.utility_gamma == 0.2
+        assert config.utility_beta_discount == 0.98
+
+    def test_out_of_range_alpha(self) -> None:
+        with pytest.raises(ValidationError):
+            SimulationConfigV2(utility_alpha=0.0)
+        with pytest.raises(ValidationError):
+            SimulationConfigV2(utility_alpha=1.0)
+
+    def test_out_of_range_discount(self) -> None:
+        with pytest.raises(ValidationError):
+            SimulationConfigV2(utility_beta_discount=0.0)
+        with pytest.raises(ValidationError):
+            SimulationConfigV2(utility_beta_discount=1.0)

--- a/tests/test_v2_initialization.py
+++ b/tests/test_v2_initialization.py
@@ -328,3 +328,64 @@ class TestInitialMarketGuess:
         m2 = _initial_market_guess(config2, ps2.households)
         # Higher alpha -> lower labor share -> lower wage (roughly)
         assert m1.wage != m2.wage
+
+
+# ============================================================================
+# Homogeneous preferences initialization tests
+# ============================================================================
+
+
+class TestHomogeneousHouseholds:
+    def test_all_agents_same_params(self) -> None:
+        """With homogeneous_preferences=True, all agents share utility params."""
+        config = SimulationConfigV2(num_agents=30, seed=42, homogeneous_preferences=True)
+        ps, _ = initialize_simulation_v2(config)
+        ref = ps.households[0].utility_params
+        for h in ps.households[1:]:
+            assert h.utility_params.alpha == ref.alpha
+            assert h.utility_params.beta == ref.beta
+            assert h.utility_params.gamma == ref.gamma
+            assert h.utility_params.beta_discount == ref.beta_discount
+
+    def test_params_match_config(self) -> None:
+        """Homogeneous params should come from config-level fields."""
+        config = SimulationConfigV2(
+            num_agents=20,
+            seed=42,
+            utility_alpha=0.5,
+            utility_beta=0.3,
+            utility_gamma=0.2,
+            utility_beta_discount=0.98,
+        )
+        ps, _ = initialize_simulation_v2(config)
+        for h in ps.households:
+            assert h.utility_params.alpha == 0.5
+            assert h.utility_params.beta == 0.3
+            assert h.utility_params.gamma == 0.2
+            assert h.utility_params.beta_discount == 0.98
+
+    def test_heterogeneous_agents_differ(self) -> None:
+        """With homogeneous_preferences=False, agents should have diverse params."""
+        config = SimulationConfigV2(num_agents=30, seed=42, homogeneous_preferences=False)
+        ps, _ = initialize_simulation_v2(config)
+        alphas = {h.utility_params.alpha for h in ps.households}
+        # With Dirichlet draw over 30 agents, should have >1 distinct alpha
+        assert len(alphas) > 1
+
+    def test_value_vector_still_heterogeneous(self) -> None:
+        """Even with homogeneous prefs, value vectors should differ."""
+        config = SimulationConfigV2(num_agents=30, seed=42, homogeneous_preferences=True)
+        ps, _ = initialize_simulation_v2(config)
+        equalities = {h.value_vector.equality for h in ps.households}
+        assert len(equalities) > 1
+
+    def test_determinism_homogeneous(self) -> None:
+        """Same seed + homogeneous should give identical results."""
+        config = SimulationConfigV2(num_agents=20, seed=77, homogeneous_preferences=True)
+        ps1, _ = initialize_simulation_v2(config)
+        ps2, _ = initialize_simulation_v2(config)
+        for h1, h2 in zip(ps1.households, ps2.households, strict=False):
+            assert h1.wealth == h2.wealth
+            assert h1.productivity == h2.productivity
+            assert h1.utility_params == h2.utility_params
+            assert h1.value_vector == h2.value_vector


### PR DESCRIPTION
## Summary
- Adds homogeneous preference mode (default on) where all agents share identical utility params, enabling VFI to be solved **once per period** instead of once per agent per period (~Nx speedup, e.g. 20x for N=20)
- Auto-detects homogeneity via `_is_homogeneous()` so the fast path activates without config dependency
- Adds `--heterogeneous` CLI flag to opt back into the slow Dirichlet-drawn per-agent path, plus `--utility-alpha/beta/gamma/discount` overrides

## Test plan
- [x] 21 new tests covering config validation, initialization branching, `_is_homogeneous` detection, `solve_vfi_shared` grid properties, and fast-path-matches-slow-path correctness
- [x] All 913 tests pass
- [x] `ruff check .` and `ruff format --check` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added new command-line flags to configure household preferences: `--heterogeneous`, `--utility-alpha`, `--utility-beta`, `--utility-gamma`, and `--utility-discount`.
  * Support for both homogeneous and heterogeneous household preference modes.
  * Configurable utility weight parameters for simulations.

* **Improvements**
  * Added validation for utility weight configurations to ensure they sum correctly when using homogeneous preferences.
  * Performance optimization for simulations with identical household preferences.

* **Tests**
  * Expanded test coverage for preference configuration and household initialization logic.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->