### PR TITLE
fix: correct DSGE-HA budget constraint and wealth dynamics

### DIFF
--- a/src/emergent_constitution/constitution_engine.py
+++ b/src/emergent_constitution/constitution_engine.py
@@ -273,9 +273,6 @@ class ConstitutionEngine:
             # Non-negativity: taxes cannot exceed income
             tax = max(0.0, min(tax, income))
             household.taxes_paid = tax
-            household.wealth -= tax
-            # Ensure wealth doesn't go below zero
-            household.wealth = max(household.wealth, 0.0)
             total_revenue += tax
 
         return updated, total_revenue
@@ -314,7 +311,6 @@ class ConstitutionEngine:
             for household in updated:
                 transfer = transfers.get(household.id, 0.0)
                 household.transfers_received += transfer
-                household.wealth += transfer
                 distributed += transfer
             remaining_revenue -= distributed
 

--- a/src/emergent_constitution/economics.py
+++ b/src/emergent_constitution/economics.py
@@ -428,10 +428,12 @@ def enforce_budget_constraint(
     else:
         budget_adjusted = budget
 
-    # Step 3: max consumption so that savings >= a_min - wealth
-    # savings = budget - consumption, a_{t+1} = wealth + savings >= a_min
-    # => consumption <= budget - (a_min - wealth) = budget - a_min + wealth
-    max_consumption = max(0.0, budget_adjusted - a_min + agent.wealth)
+    # Step 3: max consumption so that a_{t+1} >= a_min
+    # Under the DSGE-HA budget constraint:
+    #   a' = (1+r)*a + w*z*(1-l) - c - taxes + transfers
+    # The budget already equals (1+r)*a + w*z*labor - tax + transfer,
+    # so c_max = budget - a_min ensures a' >= a_min.
+    max_consumption = max(0.0, budget_adjusted - a_min)
 
     consumption = max(0.0, min(decision.consumption, max_consumption))
 

--- a/src/emergent_constitution/initialization.py
+++ b/src/emergent_constitution/initialization.py
@@ -194,6 +194,8 @@ def create_households(
                 utility_params=utility_params,
                 value_vector=value_vector,
                 role=OccupationalRole.WORKER,
+                labor_supply=0.5,
+                leisure=0.5,
             )
         )
 

--- a/src/emergent_constitution/lead.py
+++ b/src/emergent_constitution/lead.py
@@ -526,6 +526,13 @@ class LeadV2:
             econ_decisions, households, market, constitution
         )
 
+        # Step 4b: Set labor_supply and income on households from validated decisions
+        # so that Step 6 (enforce_taxes) can compute taxes on actual income.
+        for h in households:
+            decision = econ_decisions.get(h.id, EconomicDecision(consumption=0.0, leisure=0.5))
+            h.labor_supply = 1.0 - decision.leisure
+            h.income = market.wage * h.productivity * h.labor_supply
+
         # Step 5: Execute production
         firms = self._execute_production(firms, entre_decisions, households, market)
 
@@ -541,6 +548,13 @@ class LeadV2:
 
         # Step 8: Update states
         households = self._update_states(households, econ_decisions, market, public_goods)
+
+        # Update market aggregates with actual post-Step-8 values
+        market = market.model_copy(
+            update={
+                "aggregate_consumption": sum(h.consumption for h in households),
+            }
+        )
 
         # Step 9: Observe
         self._observe_period(t, households, firms, market, constitution, proposals, votes)
@@ -1027,10 +1041,17 @@ class LeadV2:
             labor_supply = 1.0 - leisure
 
             # Income from labor
-            income = market.wage * h.productivity * labor_supply
+            labor_income = market.wage * h.productivity * labor_supply
 
-            # Savings: wealth after consumption
-            new_wealth = h.wealth - consumption
+            # Full DSGE-HA budget constraint:
+            # a' = (1+r)*a + w*z*(1-l) - c - taxes + transfers
+            new_wealth = (
+                (1.0 + market.interest_rate) * h.wealth
+                + labor_income
+                - consumption
+                - h.taxes_paid
+                + h.transfers_received
+            )
             new_wealth = max(new_wealth, self.config.a_min)
             savings = new_wealth - h.wealth
 
@@ -1040,7 +1061,7 @@ class LeadV2:
                     "consumption": consumption,
                     "leisure": leisure,
                     "labor_supply": labor_supply,
-                    "income": income,
+                    "income": labor_income,
                     "savings": savings,
                     "wealth": new_wealth,
                 }

--- a/tests/test_constitution_engine.py
+++ b/tests/test_constitution_engine.py
@@ -331,7 +331,8 @@ class TestEnforceTaxes:
         )
         updated, revenue = engine.enforce_taxes(households, constitution, market)
         assert updated[0].taxes_paid <= 10.0
-        assert updated[0].wealth >= 0.0
+        # enforce_taxes no longer modifies wealth; it only records taxes_paid
+        assert updated[0].wealth == 100.0
 
     def test_original_households_not_mutated(
         self,

--- a/tests/test_lead_v2.py
+++ b/tests/test_lead_v2.py
@@ -440,6 +440,35 @@ class TestUpdateStates:
         for h in updated:
             assert h.wealth >= short_mock_config.a_min
 
+    def test_budget_constraint_formula(self, short_mock_config: SimulationConfigV2) -> None:
+        """Step 8: a' = (1+r)*a + w*z*(1-l) - c - taxes + transfers.
+
+        Verify the DSGE-HA budget constraint is correctly applied.
+        """
+        lead = LeadV2(short_mock_config)
+        households = [h.model_copy(deep=True) for h in lead.period_state.households]
+        market = lead.period_state.market
+
+        # Zero consumption and no taxes/transfers
+        decisions = {h.id: EconomicDecision(consumption=0.0, leisure=0.5) for h in households}
+        updated = lead._update_states(households, decisions, market, 0.0)
+
+        for orig, upd in zip(households, updated, strict=True):
+            labor_income = market.wage * orig.productivity * 0.5
+            expected = (
+                (1.0 + market.interest_rate) * orig.wealth
+                + labor_income
+                - 0.0  # consumption
+                - orig.taxes_paid
+                + orig.transfers_received
+            )
+            expected = max(expected, short_mock_config.a_min)
+            assert upd.wealth == pytest.approx(expected, abs=1e-8), (
+                f"Agent {orig.id}: expected {expected:.4f}, got {upd.wealth:.4f}"
+            )
+            # Labor income should be reflected in updated household
+            assert upd.income == pytest.approx(labor_income, abs=1e-8)
+
 
 class TestGiniComputation:
     """Test the Gini coefficient helper."""

--- a/tests/test_v2_economics.py
+++ b/tests/test_v2_economics.py
@@ -351,16 +351,16 @@ class TestEnforceBudgetConstraint:
         decision = EconomicDecision(consumption=500.0, leisure=0.2)
         budget = 200.0
         result = enforce_budget_constraint(decision, agent, budget, a_min=0.0)
-        # max_consumption = budget - a_min + wealth = 200 - 0 + 100 = 300
-        assert result.consumption == 300.0
+        # max_consumption = budget - a_min = 200 - 0 = 200
+        assert result.consumption == 200.0
 
     def test_a_min_constrains_consumption(self) -> None:
         agent = _make_household(wealth=100.0, labor_supply=0.8)
         decision = EconomicDecision(consumption=500.0, leisure=0.2)
         budget = 200.0
         result = enforce_budget_constraint(decision, agent, budget, a_min=50.0)
-        # max_consumption = 200 - 50 + 100 = 250
-        assert result.consumption == 250.0
+        # max_consumption = budget - a_min = 200 - 50 = 150
+        assert result.consumption == 150.0
 
     def test_zero_budget_zero_consumption(self) -> None:
         agent = _make_household(wealth=0.0, labor_supply=0.0)

--- a/tests/test_v2_initialization.py
+++ b/tests/test_v2_initialization.py
@@ -205,6 +205,13 @@ class TestCreateHouseholds:
         for h in households:
             assert h.role == OccupationalRole.WORKER
 
+    def test_initial_labor_supply(self, setup: tuple) -> None:
+        """Households start with labor_supply=0.5 for period-1 market clearing."""
+        households, _ = setup
+        for h in households:
+            assert h.labor_supply == 0.5
+            assert h.leisure == 0.5
+
     def test_unique_ids(self, setup: tuple) -> None:
         households, _ = setup
         ids = [h.id for h in households]


### PR DESCRIPTION
## Summary

- **Fix zero consumption/investment/welfare** in v2 simulation by correcting three interconnected bugs in the 9-step period lifecycle
- **enforce_taxes/enforce_transfers** no longer modify wealth directly — they only record `taxes_paid` and `transfers_received` fields, leaving the full budget constraint to Step 8
- **Step 4b** sets `labor_supply` and `income` on households from validated decisions before Step 6, so tax enforcement computes taxes on actual income (not zero)
- **Step 8** now uses the textbook DSGE-HA budget constraint: `a' = (1+r)*a + w*z*(1-l) - c - taxes + transfers`
- **enforce_budget_constraint** max consumption formula corrected for consistency (`budget - a_min` instead of `budget - a_min + wealth`)
- **Default labor_supply=0.5** at initialization for period-1 market clearing

## Test plan

- [x] All 915 tests pass
- [x] `ruff check .` and `ruff format --check .` clean
- [x] New test `test_budget_constraint_formula` verifies the DSGE-HA formula per-agent
- [x] New test `test_initial_labor_supply` checks initialization defaults
- [x] Updated `test_consumption_clamped_to_budget` and `test_a_min_constrains_consumption` for corrected formula
- [x] Quick simulation run confirms non-zero consumption, income, and welfare

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added labor supply and leisure attributes to household initialization.

* **Changes**
  * Refined tax and transfer accounting to separate from direct wealth adjustments.
  * Updated budget constraint calculations for more conservative consumption limits.
  * Enhanced economic state propagation using DSGE-HA budget flow methodology.

* **Tests**
  * Updated test expectations to verify refined economic behavior and budget constraint formulas.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->